### PR TITLE
Update CI runners and actions to non-deprecated versions

### DIFF
--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -24,8 +24,8 @@ jobs:
             host-name: linux
             targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
           
-          # macOS x64 host builds  
-          - host: macos-13
+          # macOS x64 host builds
+          - host: macos-15-intel
             host-name: macos-x64
             targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
           
@@ -39,10 +39,10 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
       
@@ -148,7 +148,7 @@ jobs:
           fi
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()  # Upload artifacts even if some builds failed
         with:
           name: binaries-${{ matrix.host-name }}
@@ -169,7 +169,7 @@ jobs:
             test-targets: "linux-x64,linux-musl-x64"
             host-sources: "windows,linux,macos-x64,macos-arm64"
           # Test macOS binaries on macOS x64
-          - runner: macos-13
+          - runner: macos-15-intel
             runner-name: macos-x64
             test-targets: "osx-x64"
             host-sources: "windows,linux,macos-x64,macos-arm64"
@@ -184,7 +184,7 @@ jobs:
     
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
       
       - name: Test binaries from all host platforms
         shell: bash
@@ -310,7 +310,7 @@ jobs:
     
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
       
       - name: Generate platform support matrix
@@ -456,7 +456,7 @@ jobs:
           cat platform-report.md >> $GITHUB_STEP_SUMMARY
       
       - name: Upload platform report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: platform-support-report
           path: platform-report.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,11 @@ jobs:
     name: Build and test ${{ matrix.vm }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
-          include-prerelease: true
       - name: Build (CI)
         if: ${{ github.event.inputs.version == '' }}
         run: |
@@ -33,7 +32,7 @@ jobs:
           dotnet publish -r linux-x64 -c Release test/Hello.csproj -p:StripSymbols=false
       - name: Upload test binary
         if: ${{ github.event.inputs.version == '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Hello
           path: test/bin/Release/net8.0/linux-x64/publish/Hello
@@ -42,7 +41,7 @@ jobs:
         run: dotnet build -t:Pack src/PublishAotCross.nuproj -p:Version=${{ github.event.inputs.version }}
       - name: Archive NuGet
         if: ${{ github.event.inputs.version != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PublishAotCross.${{ github.event.inputs.version }}.nupkg
           path: src/bin/Debug/PublishAotCross.${{ github.event.inputs.version }}.nupkg
@@ -58,7 +57,7 @@ jobs:
     name: Try launching
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
       - name: Launch
         run: |
           chmod +x ./Hello/Hello


### PR DESCRIPTION
The `macos-13` runner was retired in December 2025 and every action was pinned to a version that runs on the Node 20 runtime, which GitHub forces off by default from June 2026. This replaces `macos-13` with `macos-15-intel` in both the build and validate matrices, bumps all actions to their Node 24 releases (`checkout@v7`, `setup-dotnet@v5`, `upload-artifact@v7`, `download-artifact@v8`), and drops the stale `include-prerelease` input. The `upload-artifact@v7`/`download-artifact@v8` pair is required together for the newer artifact format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)