### PR TITLE
Add macOS signing and notarization to publish, validate in CI

### DIFF
--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -11,7 +11,9 @@ env:
   # rcodesign (https://github.com/indygreg/apple-platform-rs) generates the
   # test signing certificate, signs macOS binaries during the build matrix
   # (via the PublishAotCross signing properties) and verifies the results.
-  RCODESIGN_VERSION: 0.29.0
+  # Deliberately NOT named RCODESIGN_*: rcodesign feeds env vars with that
+  # prefix into its config loader and errors on unknown keys.
+  APPLE_CODESIGN_VERSION: 0.29.0
 
 jobs:
   # Build the prebuilt clang shims once, on a host whose zig can cross-compile
@@ -52,9 +54,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download "apple-codesign/$RCODESIGN_VERSION" \
+          gh release download "apple-codesign/$APPLE_CODESIGN_VERSION" \
             -R indygreg/apple-platform-rs \
-            -p "apple-codesign-$RCODESIGN_VERSION-x86_64-unknown-linux-musl.tar.gz"
+            -p "apple-codesign-$APPLE_CODESIGN_VERSION-x86_64-unknown-linux-musl.tar.gz"
           tar xzf apple-codesign-*.tar.gz --strip-components=1
           mkdir test-cert
           ./rcodesign generate-self-signed-certificate \
@@ -146,9 +148,9 @@ jobs:
             *) echo "No rcodesign asset for $(uname -s)-$(uname -m)"; exit 1 ;;
           esac
           mkdir .rcodesign && cd .rcodesign
-          gh release download "apple-codesign/$RCODESIGN_VERSION" \
+          gh release download "apple-codesign/$APPLE_CODESIGN_VERSION" \
             -R indygreg/apple-platform-rs \
-            -p "apple-codesign-$RCODESIGN_VERSION-$asset"
+            -p "apple-codesign-$APPLE_CODESIGN_VERSION-$asset"
           if [[ "$asset" == *.zip ]]; then
             unzip -q apple-codesign-*.zip || python -m zipfile -e apple-codesign-*.zip .
           else

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -7,6 +7,12 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+env:
+  # rcodesign (https://github.com/indygreg/apple-platform-rs) generates the
+  # test signing certificate, signs macOS binaries during the build matrix
+  # (via the PublishAotCross signing properties) and verifies the results.
+  RCODESIGN_VERSION: 0.29.0
+
 jobs:
   # Build the prebuilt clang shims once, on a host whose zig can cross-compile
   # every host's shim. The build jobs below consume these instead of compiling
@@ -33,9 +39,42 @@ jobs:
           name: prebuilt-shims
           path: src/obj/shim/
 
+  # Generate a throwaway self-signed Developer ID-style certificate that the
+  # build jobs use to exercise the signing integration. Generated once here:
+  # rcodesign emits a PEM pair, and Ubuntu's OpenSSL converts it to a PKCS#12
+  # file with -legacy — the PFX encryption rcodesign can read back.
+  test-cert:
+    runs-on: ubuntu-latest
+    name: Generate test signing certificate
+    steps:
+      - name: Generate self-signed signing certificate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "apple-codesign/$RCODESIGN_VERSION" \
+            -R indygreg/apple-platform-rs \
+            -p "apple-codesign-$RCODESIGN_VERSION-x86_64-unknown-linux-musl.tar.gz"
+          tar xzf apple-codesign-*.tar.gz --strip-components=1
+          mkdir test-cert
+          ./rcodesign generate-self-signed-certificate \
+            --person-name "PublishAotCross CI Test" \
+            --profile developer-id-application \
+            --pem-filename test-cert/cert
+          openssl pkcs12 -export -legacy \
+            -inkey test-cert/cert.key -in test-cert/cert.crt \
+            -out test-cert/cert.p12 -passout pass:citest
+          printf citest > test-cert/cert.pass
+          rm test-cert/cert.key test-cert/cert.crt
+      - name: Upload test certificate
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-signing-cert
+          path: test-cert/
+
   # Build matrix: Test building from different host platforms to different target platforms
   build:
-    needs: pack
+    needs: [pack, test-cert]
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +125,38 @@ jobs:
           name: prebuilt-shims
           path: src/shim
 
+      - name: Download test signing certificate
+        uses: actions/download-artifact@v8
+        with:
+          name: test-signing-cert
+          path: test-cert
+
+      # The osx-x64 publishes below sign via the PublishAotCross rcodesign
+      # integration, so every build host needs rcodesign on PATH.
+      - name: Install rcodesign
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64)         asset="x86_64-unknown-linux-musl.tar.gz" ;;
+            Linux-aarch64)        asset="aarch64-unknown-linux-musl.tar.gz" ;;
+            Darwin-*)             asset="macos-universal.tar.gz" ;;
+            MINGW*|MSYS*|CYGWIN*) asset="x86_64-pc-windows-msvc.zip" ;;
+            *) echo "No rcodesign asset for $(uname -s)-$(uname -m)"; exit 1 ;;
+          esac
+          mkdir .rcodesign && cd .rcodesign
+          gh release download "apple-codesign/$RCODESIGN_VERSION" \
+            -R indygreg/apple-platform-rs \
+            -p "apple-codesign-$RCODESIGN_VERSION-$asset"
+          if [[ "$asset" == *.zip ]]; then
+            unzip -q apple-codesign-*.zip || python -m zipfile -e apple-codesign-*.zip .
+          else
+            tar xzf apple-codesign-*.tar.gz
+          fi
+          mv apple-codesign-*/rcodesign* .
+          ./rcodesign --version
+
       - name: Build and publish for all target platforms
         shell: bash
         env:
@@ -93,7 +164,10 @@ jobs:
         run: |
           # Split the targets and build each one
           IFS=',' read -ra TARGET_ARRAY <<< "${{ matrix.targets }}"
-          
+
+          # rcodesign is invoked by the SignMacOsBinary target for osx-x64
+          export PATH="$PWD/.rcodesign:$PATH"
+
           build_success=true
           
           for target in "${TARGET_ARRAY[@]}"; do
@@ -123,12 +197,30 @@ jobs:
               fi
             elif [[ "$target" == osx-* ]]; then
               echo "Cross-compiling to macOS target using PublishAotCross..."
+              # osx-x64 is signed with the throwaway CI certificate to
+              # exercise the rcodesign signing integration from every host;
+              # osx-arm64 is left with zig's default ad-hoc signature so that
+              # path stays covered too.
+              sign_args=()
+              if [[ "$target" == "osx-x64" ]]; then
+                p12="$PWD/test-cert/cert.p12"
+                pass="$PWD/test-cert/cert.pass"
+                if command -v cygpath >/dev/null 2>&1; then
+                  p12=$(cygpath -w "$p12")
+                  pass=$(cygpath -w "$pass")
+                fi
+                sign_args=(
+                  "-p:PublishAotCrossSignP12File=$p12"
+                  "-p:PublishAotCrossSignP12PasswordFile=$pass"
+                )
+              fi
               # For macOS targets, use PublishAotCross for cross-compilation
               if dotnet publish test/Hello.csproj \
                 -r "$target" \
                 -c Release \
                 -p:StripSymbols=false \
                 -p:InvariantGlobalization=true \
+                "${sign_args[@]}" \
                 --output "artifacts/${{ matrix.host-name }}/$target"; then
                 
                 echo "✅ Cross-compilation build succeeded for $target"
@@ -160,7 +252,17 @@ jobs:
                 # Try to get binary size
                 size_kb=$(du -k "artifacts/${{ matrix.host-name }}/$target/$binary_name" | cut -f1)
                 echo "Binary size: ${size_kb}KB"
-                
+
+                # Assert the signing integration actually signed osx-x64
+                if [[ "$target" == "osx-x64" ]]; then
+                  if rcodesign print-signature-info "artifacts/${{ matrix.host-name }}/$target/$binary_name" | grep -q "PublishAotCross CI Test"; then
+                    echo "✅ Signature check: signed with the CI test certificate"
+                  else
+                    echo "❌ Signature check: expected CI test certificate signature not found"
+                    build_success=false
+                  fi
+                fi
+
               else
                 echo "❌ Binary not found after successful build: $binary_name for $target"
                 echo "Contents of output directory:"
@@ -292,7 +394,24 @@ jobs:
               
               # Make executable
               chmod +x "$binary_path"
-              
+
+              # macOS binaries: verify the code signature before running.
+              # osx-x64 was signed with the CI test certificate by the build
+              # job; osx-arm64 carries zig's ad-hoc linker signature. Both
+              # must pass strict verification.
+              if [[ "$target" == osx-* ]]; then
+                echo -n "  Signature check: "
+                if ! codesign --verify --strict "$binary_path"; then
+                  echo "❌ FAIL - invalid code signature"
+                  continue
+                fi
+                if [[ "$target" == "osx-x64" ]] && ! codesign -dvv "$binary_path" 2>&1 | grep -q "PublishAotCross CI Test"; then
+                  echo "❌ FAIL - not signed with the CI test certificate"
+                  continue
+                fi
+                echo "✅ valid"
+              fi
+
               # Try to run the binary with timeout
               echo -n "  Execution test: "
               if timeout 10s "$binary_path" > /tmp/output.txt 2>&1; then

--- a/README.md
+++ b/README.md
@@ -30,8 +30,69 @@ Things to know:
 
 - The stub symbol lists are generated from the .NET 8, 9, 10, and 11-preview runtime packs (`eng/generate-apple-sysroot.py`). If a future .NET version references new Apple symbols, the link fails with an unresolved symbol until the stubs are regenerated.
 - Symbols are not stripped for macOS targets (`StripSymbols` defaults to `false` there): Apple's `strip`/`dsymutil` are unavailable on other hosts and reject zig-linked binaries anyway.
-- zig gives the binary an ad-hoc code signature. That runs fine locally, but for distribution you should sign (and if needed notarize) the result on a Mac: `codesign --force --sign <identity> <binary>`.
+- zig gives osx-arm64 binaries an ad-hoc code signature (Apple Silicon refuses to run entirely unsigned code); osx-x64 binaries are left unsigned. Either way that only covers running locally — for distribution you should sign (and if needed notarize) the result, which works from any host, no Mac required; see [Signing and notarizing macOS binaries](#signing-and-notarizing-macos-binaries) below.
 - To link against a real Apple SDK instead of the bundled stubs, set the `PublishAotCrossAppleSysroot` MSBuild property (or the `PUBLISHAOTCROSS_APPLE_SYSROOT` environment variable) to the SDK root.
+
+### Signing and notarizing macOS binaries
+
+Out of the box the binaries only run locally: zig ad-hoc signs osx-arm64 output (Apple Silicon requires at least that much) and leaves osx-x64 output unsigned. That is not enough to distribute: anything downloaded with a browser gets quarantined, and Gatekeeper only clears it when the binary is signed with a Developer ID certificate and notarized by Apple. Both steps can be done from any host — no Mac required.
+
+#### Signing during publish
+
+Export your "Developer ID Application" certificate and private key as a `.p12` file, put its password in a file, and pass both to publish:
+
+```sh
+dotnet publish -r osx-arm64 \
+  /p:PublishAotCrossSignP12File=certificate.p12 \
+  /p:PublishAotCrossSignP12PasswordFile=certificate.password.txt
+```
+
+The freshly linked binary is re-signed in place with the hardened-runtime flag and a secure timestamp, so it is ready for notarization. This uses [rcodesign](https://github.com/indygreg/apple-platform-rs) and works on Windows, Linux and macOS hosts alike — install it from the GitHub releases (or `cargo install apple-codesign`), or point `PublishAotCrossRCodesignPath` at the executable if it is not on `PATH`.
+
+On a macOS host you can use Apple's `codesign` with a keychain identity instead:
+
+```sh
+dotnet publish -r osx-arm64 "/p:PublishAotCrossCodesignIdentity=Developer ID Application: Jane Doe (TEAMID)"
+```
+
+To embed entitlements with either flavor, set `/p:PublishAotCrossEntitlements=path/to/entitlements.plist`.
+
+Things to know:
+
+- The password lives in a file rather than an MSBuild property so it does not end up in build logs or binlogs. In CI, store the `.p12` (base64-encoded) and its password as secrets and write them to files before publishing.
+- If you create the `.p12` with OpenSSL 3+, pass `-legacy` (`openssl pkcs12 -export -legacy ...`). rcodesign cannot read OpenSSL 3's default PFX encryption and fails with "incorrect password given when decrypting PFX data". Exports from Keychain Access work as-is.
+- Signing happens right after the native link. On an incremental publish where the binary is up to date, the link is skipped and the existing binary is re-signed with the current properties — but if you *remove* the signing properties, the previous signature stays until something triggers a relink. Publish clean (or `dotnet clean`) when changing signing configuration.
+
+#### Notarizing
+
+Notarization is a submission to Apple's notary service and needs an [App Store Connect API key](https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_app_store_connect.html). Encode the key once:
+
+```sh
+rcodesign encode-app-store-connect-api-key -o api-key.json <issuer-id> <key-id> AuthKey_<key-id>.p8
+```
+
+Then either let the publish do everything — sign, zip, submit and wait for Apple's verdict:
+
+```sh
+dotnet publish -r osx-arm64 \
+  /p:PublishAotCrossSignP12File=certificate.p12 \
+  /p:PublishAotCrossSignP12PasswordFile=certificate.password.txt \
+  /p:PublishAotCrossNotarize=true \
+  /p:PublishAotCrossNotaryApiKeyFile=api-key.json
+```
+
+or run the submission yourself after a signed publish:
+
+```sh
+zip hello.zip Hello
+rcodesign notary-submit --api-key-file api-key.json --wait hello.zip
+```
+
+`PublishAotCrossNotarize` requires Developer ID signing in the same publish (Apple rejects ad-hoc submissions) and rcodesign, even when the signing itself was done with `PublishAotCrossCodesignIdentity`. Submission typically takes a minute or two; the publish fails if Apple rejects the binary.
+
+A bare executable cannot be stapled (stapling only works for bundles, disk images and installer packages), so just distribute the notarized binary — Gatekeeper fetches the notarization ticket online the first time it runs. If you ship a `.dmg` or `.pkg` instead, notarize that artifact and `rcodesign staple` it.
+
+Note that only browser downloads get the quarantine attribute; binaries fetched by `curl`, CI tooling or package managers typically run without any of this.
 
 ## Usage
 

--- a/docs/cross-platform-validation.md
+++ b/docs/cross-platform-validation.md
@@ -45,14 +45,18 @@ For each host-target combination:
 - Compiles the test application for each target platform
 - Validates binary creation and uploads artifacts
 
-### 3. Runtime Validation
+### 3. macOS Code Signing
+A dedicated job generates a throwaway self-signed Developer ID-style certificate with rcodesign. Every build host then publishes `osx-x64` with the `PublishAotCrossSignP12File` properties set, exercising the package's rcodesign signing integration from Windows, Linux and macOS hosts; `osx-arm64` keeps zig's default ad-hoc signature so that path stays covered. The build job asserts the expected certificate is present with `rcodesign print-signature-info`.
+
+### 4. Runtime Validation
 - Downloads build artifacts from all host platforms
 - Tests x64 binaries on Ubuntu (can't test ARM64 on x64 runners)
 - Tests macOS binaries on appropriate macOS runners (x64 on macos-13, ARM64 on macos-latest)
+- On macOS runners, verifies code signatures with `codesign --verify --strict` (and checks the `osx-x64` binaries carry the CI test certificate) before running
 - Verifies "Hello World" output
 - Reports success/failure rates
 
-### 4. Platform Support Report
+### 5. Platform Support Report
 Generates a comprehensive report showing:
 - Which host-target combinations work
 - Binary sizes and architecture information

--- a/src/Crosscompile.targets
+++ b/src/Crosscompile.targets
@@ -183,4 +183,126 @@
   </Target>
   <!-- END: Works around ILCompiler targets not detecting this as a cross compilation -->
 
+  <!-- zig leaves an ad-hoc code signature on macOS binaries, which runs
+       locally but is not suitable for distribution. This re-signs the linked
+       binary with a real identity, from any host:
+         - PublishAotCrossSignP12File / PublishAotCrossSignP12PasswordFile:
+           sign with a Developer ID certificate using rcodesign
+           (https://github.com/indygreg/apple-platform-rs), works on
+           Windows/Linux/macOS hosts
+         - PublishAotCrossCodesignIdentity: sign with Apple's codesign,
+           macOS hosts only (takes precedence there when both are set)
+       Both paths apply the hardened-runtime flag and a secure timestamp so
+       the result is ready for notarization. -->
+  <Target Name="SignMacOsBinary"
+          AfterTargets="LinkNative"
+          Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+
+    <PropertyGroup>
+      <PublishAotCrossRCodesignPath Condition="'$(PublishAotCrossRCodesignPath)' == ''">rcodesign</PublishAotCrossRCodesignPath>
+
+      <_UseCodesign>false</_UseCodesign>
+      <_UseCodesign Condition="'$(PublishAotCrossCodesignIdentity)' != '' and $([MSBuild]::IsOSPlatform('OSX'))">true</_UseCodesign>
+      <_UseRCodesign>false</_UseRCodesign>
+      <_UseRCodesign Condition="'$(_UseCodesign)' != 'true' and '$(PublishAotCrossSignP12File)' != ''">true</_UseRCodesign>
+
+      <!-- Timestamping needs a real certificate; skip it for the ad-hoc
+           identity so /p:PublishAotCrossCodesignIdentity=- also works. -->
+      <_CodesignTimestampArg>--timestamp</_CodesignTimestampArg>
+      <_CodesignTimestampArg Condition="'$(PublishAotCrossCodesignIdentity)' == '-'">--timestamp=none</_CodesignTimestampArg>
+
+      <_CodesignEntitlementsArg Condition="'$(PublishAotCrossEntitlements)' != ''">--entitlements &quot;$(PublishAotCrossEntitlements)&quot;</_CodesignEntitlementsArg>
+      <!-- -e is the stable alias: the long form was renamed from
+           entitlements-xml-path to entitlements-xml-file across rcodesign releases. -->
+      <_RCodesignEntitlementsArg Condition="'$(PublishAotCrossEntitlements)' != ''">-e &quot;$(PublishAotCrossEntitlements)&quot;</_RCodesignEntitlementsArg>
+    </PropertyGroup>
+
+    <Message Importance="high"
+             Condition="'$(_UseCodesign)' != 'true' and '$(_UseRCodesign)' != 'true' and '$(PublishAotCrossCodesignIdentity)' == ''"
+             Text="PublishAotCross: the produced binary carries only an ad-hoc code signature. It runs locally, but to distribute it sign with a Developer ID certificate: set PublishAotCrossSignP12File (any host) or PublishAotCrossCodesignIdentity (macOS hosts). See the README for details." />
+
+    <Error Condition="'$(PublishAotCrossCodesignIdentity)' != '' and '$(_UseCodesign)' != 'true' and '$(_UseRCodesign)' != 'true'"
+           Text="PublishAotCrossCodesignIdentity uses Apple's codesign, which only exists on macOS hosts. On this host set PublishAotCrossSignP12File and PublishAotCrossSignP12PasswordFile to sign with rcodesign instead." />
+    <Error Condition="'$(_UseRCodesign)' == 'true' and !Exists('$(PublishAotCrossSignP12File)')"
+           Text="PublishAotCrossSignP12File '$(PublishAotCrossSignP12File)' does not exist." />
+    <Error Condition="'$(_UseRCodesign)' == 'true' and '$(PublishAotCrossSignP12PasswordFile)' == ''"
+           Text="Set PublishAotCrossSignP12PasswordFile to a file containing the .p12 password. It is a file (not a plain property) so the password does not end up in build logs; rcodesign would otherwise prompt for it and hang the build." />
+    <Error Condition="'$(_UseRCodesign)' == 'true' and '$(PublishAotCrossSignP12PasswordFile)' != '' and !Exists('$(PublishAotCrossSignP12PasswordFile)')"
+           Text="PublishAotCrossSignP12PasswordFile '$(PublishAotCrossSignP12PasswordFile)' does not exist." />
+    <Error Condition="'$(PublishAotCrossEntitlements)' != '' and !Exists('$(PublishAotCrossEntitlements)')"
+           Text="PublishAotCrossEntitlements '$(PublishAotCrossEntitlements)' does not exist." />
+
+    <!-- Probe for rcodesign first to fail with instructions instead of a
+         cryptic 'command not found'. -->
+    <Exec Condition="'$(_UseRCodesign)' == 'true'"
+          Command="&quot;$(PublishAotCrossRCodesignPath)&quot; --version"
+          IgnoreExitCode="true"
+          EchoOff="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low">
+      <Output TaskParameter="ExitCode" PropertyName="_RCodesignProbeExitCode" />
+    </Exec>
+    <Error Condition="'$(_UseRCodesign)' == 'true' and '$(_RCodesignProbeExitCode)' != '0'"
+           Text="rcodesign was not found at '$(PublishAotCrossRCodesignPath)'. Install it from https://github.com/indygreg/apple-platform-rs/releases (or 'cargo install apple-codesign'), or point PublishAotCrossRCodesignPath at the executable." />
+
+    <Message Importance="high" Condition="'$(_UseCodesign)' == 'true'"
+             Text="Signing $(NativeBinary) with codesign identity '$(PublishAotCrossCodesignIdentity)'" />
+    <Exec Condition="'$(_UseCodesign)' == 'true'"
+          Command="codesign --force --options runtime $(_CodesignTimestampArg) $(_CodesignEntitlementsArg) --sign &quot;$(PublishAotCrossCodesignIdentity)&quot; &quot;$(NativeBinary)&quot;" />
+
+    <Message Importance="high" Condition="'$(_UseRCodesign)' == 'true'"
+             Text="Signing $(NativeBinary) with rcodesign using '$(PublishAotCrossSignP12File)'" />
+    <Exec Condition="'$(_UseRCodesign)' == 'true'"
+          Command="&quot;$(PublishAotCrossRCodesignPath)&quot; sign --p12-file &quot;$(PublishAotCrossSignP12File)&quot; --p12-password-file &quot;$(PublishAotCrossSignP12PasswordFile)&quot; --code-signature-flags runtime $(_RCodesignEntitlementsArg) &quot;$(NativeBinary)&quot;" />
+
+  </Target>
+
+  <!-- Opt-in notarization (PublishAotCrossNotarize=true): zips the signed
+       binary and submits it to Apple's notary service with rcodesign, waiting
+       for the verdict. Needs an App Store Connect API key encoded with
+       'rcodesign encode-app-store-connect-api-key' and a Developer ID
+       signature (Apple rejects ad-hoc or self-signed submissions). The zip is
+       only a submission container; distribute the binary itself — Gatekeeper
+       fetches the notarization ticket online, since bare executables cannot
+       be stapled. -->
+  <Target Name="NotarizeMacOsBinary"
+          AfterTargets="SignMacOsBinary"
+          Condition="$(RuntimeIdentifier.StartsWith('osx')) and '$(PublishAotCrossNotarize)' == 'true'">
+
+    <PropertyGroup>
+      <PublishAotCrossRCodesignPath Condition="'$(PublishAotCrossRCodesignPath)' == ''">rcodesign</PublishAotCrossRCodesignPath>
+      <_NotaryStagingDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'publishaotcross', 'notary'))</_NotaryStagingDir>
+      <_NotaryZip>$(_NotaryStagingDir)$(TargetName).zip</_NotaryZip>
+    </PropertyGroup>
+
+    <Error Condition="'$(PublishAotCrossSignP12File)' == '' and ('$(PublishAotCrossCodesignIdentity)' == '' or '$(PublishAotCrossCodesignIdentity)' == '-')"
+           Text="PublishAotCrossNotarize requires signing with a Developer ID certificate in the same publish; set PublishAotCrossSignP12File or PublishAotCrossCodesignIdentity. Apple rejects ad-hoc signed submissions." />
+    <Error Condition="'$(PublishAotCrossNotaryApiKeyFile)' == ''"
+           Text="Set PublishAotCrossNotaryApiKeyFile to an App Store Connect API key encoded with 'rcodesign encode-app-store-connect-api-key'." />
+    <Error Condition="'$(PublishAotCrossNotaryApiKeyFile)' != '' and !Exists('$(PublishAotCrossNotaryApiKeyFile)')"
+           Text="PublishAotCrossNotaryApiKeyFile '$(PublishAotCrossNotaryApiKeyFile)' does not exist." />
+
+    <Exec Command="&quot;$(PublishAotCrossRCodesignPath)&quot; --version"
+          IgnoreExitCode="true"
+          EchoOff="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low">
+      <Output TaskParameter="ExitCode" PropertyName="_RCodesignNotaryProbeExitCode" />
+    </Exec>
+    <Error Condition="'$(_RCodesignNotaryProbeExitCode)' != '0'"
+           Text="rcodesign was not found at '$(PublishAotCrossRCodesignPath)'; it is required for notarization. Install it from https://github.com/indygreg/apple-platform-rs/releases (or 'cargo install apple-codesign'), or point PublishAotCrossRCodesignPath at the executable." />
+
+    <!-- Stage into a directory holding just the binary so the zip contains a
+         single root entry. -->
+    <RemoveDir Directories="$(_NotaryStagingDir)" />
+    <MakeDir Directories="$(_NotaryStagingDir)bin" />
+    <Copy SourceFiles="$(NativeBinary)" DestinationFolder="$(_NotaryStagingDir)bin" />
+    <ZipDirectory SourceDirectory="$(_NotaryStagingDir)bin" DestinationFile="$(_NotaryZip)" Overwrite="true" />
+
+    <Message Importance="high" Text="Submitting $(NativeBinary) to Apple's notary service (this waits for the verdict and can take a few minutes)" />
+    <Exec Command="&quot;$(PublishAotCrossRCodesignPath)&quot; notary-submit --api-key-file &quot;$(PublishAotCrossNotaryApiKeyFile)&quot; --wait &quot;$(_NotaryZip)&quot;" />
+    <Message Importance="high" Text="Notarization accepted. Distribute the binary as-is: Gatekeeper fetches the ticket online on first run (bare executables cannot be stapled)." />
+
+  </Target>
+
 </Project>

--- a/src/clang_shim.zig
+++ b/src/clang_shim.zig
@@ -42,6 +42,17 @@ pub fn main(init: std.process.Init) !void {
     var out: Args = .empty;
     try out.appendSlice(arena, &.{ "zig", "cc" });
 
+    if (isQueryInvocation(args)) {
+        // Toolchain queries (the ILC targets probe `clang --version` on
+        // macOS hosts) pass through with no injected flags, since callers
+        // parse the output. zig 0.16's `zig cc` drops a stray zero-byte a.o
+        // in the working directory even for pure queries, so these run with
+        // the shim's own (intermediate output) directory as cwd instead of
+        // the caller's project directory.
+        try out.appendSlice(arena, args);
+        runZigCcQuery(arena, io, out.items);
+    }
+
     if (detectMacosTarget(args)) {
         if (host_is_macos) {
             say("[clang shim] Detected native macOS compilation.", .{});
@@ -69,6 +80,17 @@ pub fn main(init: std.process.Init) !void {
     }
 
     runZigCc(io, out.items);
+}
+
+/// True for invocations that only query the toolchain and produce no
+/// compile or link output.
+fn isQueryInvocation(args: []const []const u8) bool {
+    if (args.len == 0) return true;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-###"))
+            return true;
+    }
+    return false;
 }
 
 fn detectMacosTarget(args: []const []const u8) bool {
@@ -291,6 +313,26 @@ fn runZigCc(io: std.Io, argv: []const []const u8) noreturn {
     std.process.exit(127);
 }
 
+/// Runs a toolchain query as a child process with the shim's own directory
+/// as cwd (see the query branch in main), forwarding output and exit code.
+fn runZigCcQuery(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) noreturn {
+    var cwd: std.process.Child.Cwd = .inherit;
+    if (std.process.executablePathAlloc(io, gpa)) |self_path| {
+        if (std.fs.path.dirname(self_path)) |dir| cwd = .{ .path = dir };
+    } else |_| {}
+
+    const result = std.process.run(gpa, io, .{ .argv = argv, .cwd = cwd }) catch |err| {
+        reportSpawnError(err);
+        std.process.exit(127);
+    };
+    std.Io.File.stdout().writeStreamingAll(io, result.stdout) catch {};
+    std.Io.File.stderr().writeStreamingAll(io, result.stderr) catch {};
+    switch (result.term) {
+        .exited => |code| std.process.exit(code),
+        else => std.process.exit(1),
+    }
+}
+
 fn reportSpawnError(err: anyerror) void {
     if (err == error.FileNotFound) {
         std.debug.print("Error: zig is not on the PATH.\n", .{});
@@ -306,6 +348,14 @@ const testing = std.testing;
 fn expectArgs(expected: []const []const u8, actual: []const []const u8) !void {
     try testing.expectEqual(expected.len, actual.len);
     for (expected, actual) |e, a| try testing.expectEqualStrings(e, a);
+}
+
+test "query invocations pass through untouched" {
+    try testing.expect(isQueryInvocation(&.{"--version"}));
+    try testing.expect(isQueryInvocation(&.{ "-v", "--version" }));
+    try testing.expect(isQueryInvocation(&.{}));
+    try testing.expect(!isQueryInvocation(&.{ "-o", "hello", "main.o" }));
+    try testing.expect(!isQueryInvocation(&.{ "-c", "-o", "main.o", "main.c" }));
 }
 
 test "target detection" {


### PR DESCRIPTION
Publishing for macOS targets can now produce distribution-ready binaries from any host: a new `SignMacOsBinary` target signs during publish with a Developer ID `.p12` via [rcodesign](https://github.com/indygreg/apple-platform-rs) (Windows/Linux/macOS) or Apple's `codesign` (macOS hosts), applying the hardened-runtime flag and a secure timestamp, and an opt-in `NotarizeMacOsBinary` target zips and submits the result to Apple's notary service. CI now generates a throwaway signing certificate, publishes osx-x64 signed from every build host through the new integration, and verifies signatures with `rcodesign` and `codesign --verify --strict` on the macOS runners (osx-arm64 keeps zig's default ad-hoc path covered). The clang shim now runs toolchain queries like `clang --version` with no injected flags and with the shim's own directory as cwd, fixing the stray zero-byte `a.o` that zig cc dropped into the project directory on every macOS-target publish. The README documents the signing/notarization flows and corrects a subtlety found along the way: osx-x64 output was previously entirely unsigned, since zig only ad-hoc signs arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)