### PR TITLE
Add linux-arm and linux-musl-arm targets

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -100,8 +100,10 @@ When modifying the clang shim, focus on these key areas:
 # Test all supported target platforms from repository root
 dotnet publish test/Hello.csproj -r linux-x64
 dotnet publish test/Hello.csproj -r linux-arm64
+dotnet publish test/Hello.csproj -r linux-arm       # armv7; publishes as net9.0
 dotnet publish test/Hello.csproj -r linux-musl-x64
 dotnet publish test/Hello.csproj -r linux-musl-arm64
+dotnet publish test/Hello.csproj -r linux-musl-arm  # armv7; publishes as net9.0
 dotnet publish test/Hello.csproj -r osx-x64     # Experimental
 dotnet publish test/Hello.csproj -r osx-arm64   # Experimental
 ```

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -84,39 +84,44 @@ jobs:
           # Windows host builds
           - host: windows-latest
             host-name: windows
-            targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+            targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
           
           # Linux host builds
           - host: ubuntu-latest
             host-name: linux
-            targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+            targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
           
           # macOS x64 host builds
           - host: macos-15-intel
             host-name: macos-x64
-            targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+            targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
           
           # macOS ARM64 host builds
           - host: macos-latest
             host-name: macos-arm64
-            targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+            targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
 
           # Linux ARM64 host builds
           - host: ubuntu-24.04-arm
             host-name: linux-arm64
-            targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+            targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
 
     runs-on: ${{ matrix.host }}
     name: Build from ${{ matrix.host-name }}
-    
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
-      
+
+      # SDK 9 is needed on top of 8 because the armv7 targets publish as
+      # net9.0 (their ILCompiler runtime packs only ship for .NET 9+); the
+      # other targets keep exercising the net8.0 floor.
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
       
       # Drop the prebuilt shims where StuDev.AotAnywhere.targets looks for them
       # (src/shim/<host-rid>), so the publishes below use this host's prebuilt
@@ -327,6 +332,16 @@ jobs:
             runner-name: ubuntu-arm64
             test-targets: "linux-arm64,linux-musl-arm64"
             host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
+          # Test ARMv7 binaries under QEMU on Ubuntu x64: there is no hosted
+          # armv7 runner, and the hosted arm64 runners (Cobalt 100) dropped
+          # 32-bit AArch32 execution, so emulation is the only option. The
+          # binaries run inside linux/arm/v7 containers - Debian for the
+          # glibc target (it needs an armhf userland), Alpine for musl.
+          - runner: ubuntu-latest
+            runner-name: ubuntu-armv7-qemu
+            test-targets: "linux-arm,linux-musl-arm"
+            host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
+            qemu: true
           # Test macOS binaries on macOS x64
           - runner: macos-15-intel
             runner-name: macos-x64
@@ -344,7 +359,22 @@ jobs:
     steps:
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
-      
+
+      # Registers qemu-user binfmt handlers so docker can run linux/arm/v7
+      # containers on the x64 runner. Images are pulled up front so the pull
+      # time never eats into the per-binary execution timeout.
+      - name: Set up QEMU for armv7
+        if: matrix.qemu == true
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm
+
+      - name: Pre-pull armv7 test images
+        if: matrix.qemu == true
+        run: |
+          docker pull --platform linux/arm/v7 debian:bookworm-slim
+          docker pull --platform linux/arm/v7 alpine:3.21
+
       - name: Test binaries from all host platforms
         shell: bash
         run: |
@@ -369,6 +399,20 @@ jobs:
           else
             run_with_timeout() { perl -e 'alarm shift; exec @ARGV' 10 "$@"; }
           fi
+
+          # armv7 binaries execute inside arm/v7 containers via the QEMU
+          # binfmt handlers registered above; everything else runs natively.
+          # Emulation is slow, so the container path gets a longer timeout.
+          run_binary() {
+            if [[ "${{ matrix.qemu }}" == "true" ]]; then
+              local image="debian:bookworm-slim"
+              [[ "$1" == */linux-musl-*/* ]] && image="alpine:3.21"
+              timeout 120s docker run --rm --platform linux/arm/v7 \
+                -v "$PWD:/work" -w /work "$image" "/work/$1"
+            else
+              run_with_timeout "$1"
+            fi
+          }
           
           success_count=0
           total_count=0
@@ -461,7 +505,7 @@ jobs:
 
               # Try to run the binary with timeout
               echo -n "  Execution test: "
-              if run_with_timeout "$binary_path" > /tmp/output.txt 2>&1; then
+              if run_binary "$binary_path" > /tmp/output.txt 2>&1; then
                 output=$(cat /tmp/output.txt)
                 if [[ "$output" == "Hello World" ]]; then
                   echo "✅ SUCCESS - Output: '$output'"
@@ -571,7 +615,7 @@ jobs:
           echo "| Target Platform | Windows Host | Linux Host | macOS x64 Host | macOS ARM64 Host | Linux ARM64 Host | Runtime Validation |" >> platform-report.md
           echo "|-----------------|--------------|------------|----------------|------------------|------------------|-------------------|" >> platform-report.md
 
-          for target in linux-x64 linux-arm64 linux-musl-x64 linux-musl-arm64 osx-x64 osx-arm64; do
+          for target in linux-x64 linux-arm64 linux-arm linux-musl-x64 linux-musl-arm64 linux-musl-arm osx-x64 osx-arm64; do
             win_status="❌"
             linux_status="❌"
             mac_x64_status="❌"
@@ -636,8 +680,8 @@ jobs:
           echo "## Additional Notes" >> platform-report.md
           echo "- This matrix shows cross-compilation capabilities from different host platforms" >> platform-report.md
           echo "- Builds run from x64 and ARM64 Windows, Linux, and macOS hosts" >> platform-report.md
-          echo "- Runtime validation covers Linux (x64 and ARM64) and macOS (x64 and ARM64) targets on matching hosted runners" >> platform-report.md
-          echo "- All builds use .NET 8.0 with Native AOT and Zig for cross-compilation" >> platform-report.md
+          echo "- Runtime validation covers Linux (x64 and ARM64) and macOS (x64 and ARM64) targets on matching hosted runners; ARMv7 targets run under QEMU in arm/v7 containers" >> platform-report.md
+          echo "- All builds use .NET 8.0 with Native AOT and Zig for cross-compilation, except the ARMv7 targets which use .NET 9.0 (their ILCompiler packs only ship for .NET 9+)" >> platform-report.md
           echo "" >> platform-report.md
           echo "Generated on: $(date -u)" >> platform-report.md
           

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ $ dotnet publish -r linux-x64
 Microsoft.NETCore.Native.Publish.targets(59,5): error : Cross-OS native compilation is not supported.
 ```
 
-This NuGet package allows using [Zig](https://ziglang.org/) as the linker/sysroot to allow crosscompiling to linux-x64/linux-arm64/linux-musl-x64/linux-musl-arm64 from Windows and macOS machines.
+This NuGet package allows using [Zig](https://ziglang.org/) as the linker/sysroot to allow crosscompiling to linux-x64/linux-arm64/linux-arm/linux-musl-x64/linux-musl-arm64/linux-musl-arm from Windows and macOS machines.
 
 ## Supported Host Platforms
 
@@ -106,8 +106,12 @@ By default it relies on Zig provided by the unofficial [Vezel.Zig.Toolsets](http
 2. Publish for one of the newly available RIDs:
     * `dotnet publish -r linux-x64`
     * `dotnet publish -r linux-arm64`
+    * `dotnet publish -r linux-arm` (requires .NET 9+)
     * `dotnet publish -r linux-musl-x64`
     * `dotnet publish -r linux-musl-arm64`
+    * `dotnet publish -r linux-musl-arm` (requires .NET 9+)
+
+   The armv7 targets (`linux-arm`, `linux-musl-arm`) need a `net9.0` or later target framework: .NET only ships ILCompiler runtime packs for them from .NET 9 onwards.
 
 No other tools are needed. That includes symbol stripping (`StripSymbols` defaults to `true` for Linux targets): the shim doubles as `llvm-objcopy` and performs the strip, the `.dbg` symbol sidecar and the `.gnu_debuglink` itself, so no LLVM install is required. The `.dbg` sidecar it produces is a full copy of the unstripped binary — larger than llvm-objcopy's, but debuggers consume it the same way via the debug link.
 
@@ -160,6 +164,6 @@ Even though Zig allows crosscompiling for Windows as well, it's not possible to 
 
 ## Cross-Platform Validation
 
-This repository includes a comprehensive GitHub Actions workflow that validates cross-compilation support across different host and target platforms. The workflow tests building from Windows and macOS hosts to all supported Linux targets (x64, ARM64, glibc, musl) and validates that the produced binaries run correctly.
+This repository includes a comprehensive GitHub Actions workflow that validates cross-compilation support across different host and target platforms. The workflow tests building from Windows and macOS hosts to all supported Linux targets (x64, ARM64, ARMv7, glibc, musl) and validates that the produced binaries run correctly (natively on hosted runners, or under QEMU in arm/v7 containers for the ARMv7 targets).
 
 See [docs/cross-platform-validation.md](docs/cross-platform-validation.md) for detailed information about the validation process and platform support matrix.

--- a/docs/cross-platform-validation.md
+++ b/docs/cross-platform-validation.md
@@ -12,8 +12,10 @@ This repository includes a comprehensive GitHub Actions workflow (`cross-platfor
 ### Target Platforms
 - `linux-x64`
 - `linux-arm64`
+- `linux-arm` (armv7, published as `net9.0` — ILCompiler packs for armv7 only ship for .NET 9+)
 - `linux-musl-x64`
 - `linux-musl-arm64`
+- `linux-musl-arm` (armv7, published as `net9.0`)
 - `osx-x64`
 - `osx-arm64`
 
@@ -28,13 +30,9 @@ strategy:
     include:
       - host: windows-latest
         host-name: windows
-        targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
-      - host: macos-13
-        host-name: macos-x64
-        targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
-      - host: macos-latest
-        host-name: macos-arm64
-        targets: "linux-x64,linux-arm64,linux-musl-x64,linux-musl-arm64,osx-x64,osx-arm64"
+        targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
+      # ... same target list from ubuntu-latest, ubuntu-24.04-arm,
+      # macos-15-intel and macos-latest hosts
 ```
 
 ### 2. Build Process
@@ -50,8 +48,9 @@ A dedicated job generates a throwaway self-signed Developer ID-style certificate
 
 ### 4. Runtime Validation
 - Downloads build artifacts from all host platforms
-- Tests x64 binaries on Ubuntu (can't test ARM64 on x64 runners)
-- Tests macOS binaries on appropriate macOS runners (x64 on macos-13, ARM64 on macos-latest)
+- Tests x64 binaries on Ubuntu x64 and ARM64 binaries on Ubuntu ARM64 runners
+- Tests ARMv7 binaries under QEMU on the x64 runner, inside `linux/arm/v7` containers (Debian for the glibc target, Alpine for musl) — there is no hosted armv7 runner, and the hosted arm64 runners dropped 32-bit execution
+- Tests macOS binaries on appropriate macOS runners (x64 on macos-15-intel, ARM64 on macos-latest)
 - On macOS runners, verifies code signatures with `codesign --verify --strict` (and checks the `osx-x64` binaries carry the CI test certificate) before running
 - Verifies "Hello World" output
 - Reports success/failure rates
@@ -75,13 +74,12 @@ The workflow can be triggered by:
 The workflow validates that AotAnywhere successfully enables:
 - Cross-compilation from Windows/macOS to Linux and macOS
 - Support for both glibc and musl targets on Linux
-- Support for both x64 and ARM64 architectures
+- Support for x64, ARM64 and ARMv7 architectures
 - Functional binaries that run correctly on target platforms
 
 ## Limitations
 
-- ARM64 binaries cannot be runtime-tested on x64 GitHub runners
-- Cross-architecture testing (e.g., ARM64 binaries on x64 runners) is not supported
+- ARMv7 runtime testing happens under QEMU user emulation, not real hardware
 - Network connectivity required for downloading Zig toolchain
 - Build time varies significantly based on platform and target
 

--- a/src/Crosscompile.targets
+++ b/src/Crosscompile.targets
@@ -173,10 +173,17 @@
       <CrossCompileArch />
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-x64'))">x86_64</CrossCompileArch>
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm64'))">aarch64</CrossCompileArch>
+      <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm'))">arm</CrossCompileArch>
+
+      <!-- armv7 (linux-arm, linux-musl-arm) uses the hard-float ABI, which
+           the triple carries as a suffix: arm-linux-gnueabihf /
+           arm-linux-musleabihf. The 64-bit triples have no such suffix. -->
+      <CrossCompileAbiSuffix />
+      <CrossCompileAbiSuffix Condition="'$(CrossCompileArch)' == 'arm'">eabihf</CrossCompileAbiSuffix>
 
       <TargetTriple />
-      <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('linux'))">$(CrossCompileArch)-linux-gnu</TargetTriple>
-      <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-linux-musl</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('linux'))">$(CrossCompileArch)-linux-gnu$(CrossCompileAbiSuffix)</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-linux-musl$(CrossCompileAbiSuffix)</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('osx'))">$(CrossCompileArch)-macos</TargetTriple>
 
       <!-- Apple's strip/dsymutil reject zig-linked binaries (and don't exist

--- a/src/objcopy_shim.zig
+++ b/src/objcopy_shim.zig
@@ -21,8 +21,9 @@
 //! of what debuggers need, and the --add-gnu-debuglink CRC is computed over
 //! the sidecar as written, so the debuglink match holds.
 //!
-//! Only 64-bit little-endian ELF is supported - that covers every Linux
-//! target .NET ships runtime packs for (x64 and arm64, glibc and musl).
+//! Little-endian ELF is supported in both classes - ELF64 (x64, arm64) and
+//! ELF32 (armv7) - which covers every Linux target .NET ships runtime packs
+//! for, glibc and musl alike.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -58,7 +59,7 @@ pub fn run(arena: Allocator, io: std.Io, args: []const []const u8) noreturn {
             opts.debuglink_path = args[i];
         } else if (matchesAny(arg, &.{ "--version", "-V" })) {
             const stdout = std.Io.File.stdout();
-            stdout.writeStreamingAll(io, "AotAnywhere llvm-objcopy shim (ELF64, .NET Native AOT strip support)\n") catch {};
+            stdout.writeStreamingAll(io, "AotAnywhere llvm-objcopy shim (ELF32/ELF64, .NET Native AOT strip support)\n") catch {};
             std.process.exit(0);
         } else if (arg.len > 1 and arg[0] == '-') {
             fatal(io, "unsupported option '{s}' (supported: --strip-debug, --strip-unneeded, --strip-all, --only-keep-debug, --add-gnu-debuglink=<file>, --version)", .{arg});
@@ -120,7 +121,7 @@ fn fatalParse(io: std.Io, path: []const u8, err: ParseError) noreturn {
     switch (err) {
         error.OutOfMemory => fatal(io, "out of memory", .{}),
         error.NotElf => fatal(io, "'{s}' is not an ELF file", .{path}),
-        error.UnsupportedElf => fatal(io, "'{s}': only 64-bit little-endian ELF executables are supported", .{path}),
+        error.UnsupportedElf => fatal(io, "'{s}': only little-endian ELF executables (ELF32 or ELF64) are supported", .{path}),
         error.Malformed => fatal(io, "'{s}': malformed ELF", .{path}),
         error.NoSections => fatal(io, "'{s}' has no section headers", .{path}),
     }
@@ -196,6 +197,36 @@ const SHT_REL: u32 = 9;
 /// ELF extended-numbering scheme (real count in shdr[0]) starts at 0xff00.
 const max_sections = 0xff00;
 
+/// ELF comes in two classes with different header layouts: ELF64 for the
+/// x64/arm64 targets and ELF32 for armv7 (linux-arm, linux-musl-arm). Section
+/// header fields are widened to u64 in `Shdr` on parse and narrowed back on
+/// write, so the rewrite logic itself is class-agnostic.
+const Class = enum {
+    elf32,
+    elf64,
+
+    fn ehSize(class: Class) usize {
+        return switch (class) {
+            .elf32 => 52,
+            .elf64 => 64,
+        };
+    }
+
+    fn phEntSize(class: Class) u16 {
+        return switch (class) {
+            .elf32 => 32,
+            .elf64 => 56,
+        };
+    }
+
+    fn shEntSize(class: Class) u16 {
+        return switch (class) {
+            .elf32 => 40,
+            .elf64 => 64,
+        };
+    }
+};
+
 const Shdr = struct {
     name: u32,
     shtype: u32,
@@ -210,6 +241,7 @@ const Shdr = struct {
 };
 
 const Parsed = struct {
+    class: Class,
     shoff: usize,
     shnum: u16,
     shstrndx: u16,
@@ -225,36 +257,61 @@ const Parsed = struct {
 const ParseError = error{ OutOfMemory, NotElf, UnsupportedElf, Malformed, NoSections };
 
 fn parseElf(gpa: Allocator, data: []const u8) ParseError!Parsed {
-    if (data.len < 64 or !std.mem.eql(u8, data[0..4], "\x7fELF")) return error.NotElf;
-    if (data[4] != 2 or data[5] != 1) return error.UnsupportedElf; // ELFCLASS64, ELFDATA2LSB
+    if (data.len < 52 or !std.mem.eql(u8, data[0..4], "\x7fELF")) return error.NotElf;
+    const class: Class = switch (data[4]) {
+        1 => .elf32,
+        2 => .elf64,
+        else => return error.UnsupportedElf,
+    };
+    if (data[5] != 1) return error.UnsupportedElf; // ELFDATA2LSB
+    if (data.len < class.ehSize()) return error.NotElf;
+    // ELF32 file offsets are 32-bit; a bigger file cannot be a valid ELF32
+    // image, and rejecting it keeps every rewritten offset representable.
+    if (class == .elf32 and data.len > std.math.maxInt(u32)) return error.Malformed;
 
-    const phoff = rd(u64, data, 32);
-    const shoff = rd(u64, data, 40);
-    const phentsize = rd(u16, data, 54);
-    const phnum = rd(u16, data, 56);
-    const shentsize = rd(u16, data, 58);
-    const shnum = rd(u16, data, 60);
-    const shstrndx = rd(u16, data, 62);
+    const phoff: u64 = switch (class) {
+        .elf32 => rd(u32, data, 28),
+        .elf64 => rd(u64, data, 32),
+    };
+    const shoff: u64 = switch (class) {
+        .elf32 => rd(u32, data, 32),
+        .elf64 => rd(u64, data, 40),
+    };
+    const ehsize_field_off: usize = switch (class) {
+        .elf32 => 40,
+        .elf64 => 52,
+    };
+    const phentsize = rd(u16, data, ehsize_field_off + 2);
+    const phnum = rd(u16, data, ehsize_field_off + 4);
+    const shentsize = rd(u16, data, ehsize_field_off + 6);
+    const shnum = rd(u16, data, ehsize_field_off + 8);
+    const shstrndx = rd(u16, data, ehsize_field_off + 10);
 
     if (shoff == 0 or shnum == 0) return error.NoSections;
     if (shnum >= max_sections or shstrndx >= max_sections) return error.UnsupportedElf; // extended numbering
-    if (shentsize != 64) return error.Malformed;
+    if (shentsize != class.shEntSize()) return error.Malformed;
     if (shstrndx >= shnum) return error.Malformed;
 
-    const sh_end = std.math.add(u64, shoff, @as(u64, shnum) * 64) catch return error.Malformed;
+    const sh_end = std.math.add(u64, shoff, @as(u64, shnum) * class.shEntSize()) catch return error.Malformed;
     if (sh_end > data.len) return error.Malformed;
 
-    var ph_end: u64 = 64; // ELF header
+    var ph_end: u64 = class.ehSize(); // ELF header
     if (phnum > 0) {
-        if (phentsize != 56) return error.Malformed;
-        const pht_end = std.math.add(u64, phoff, @as(u64, phnum) * 56) catch return error.Malformed;
+        if (phentsize != class.phEntSize()) return error.Malformed;
+        const pht_end = std.math.add(u64, phoff, @as(u64, phnum) * class.phEntSize()) catch return error.Malformed;
         if (pht_end > data.len) return error.Malformed;
         ph_end = @max(ph_end, pht_end);
         var p: usize = 0;
         while (p < phnum) : (p += 1) {
-            const base: usize = @intCast(phoff + p * 56);
-            const p_offset = rd(u64, data, base + 8);
-            const p_filesz = rd(u64, data, base + 32);
+            const base: usize = @intCast(phoff + p * class.phEntSize());
+            const p_offset: u64 = switch (class) {
+                .elf32 => rd(u32, data, base + 4),
+                .elf64 => rd(u64, data, base + 8),
+            };
+            const p_filesz: u64 = switch (class) {
+                .elf32 => rd(u32, data, base + 16),
+                .elf64 => rd(u64, data, base + 32),
+            };
             const seg_end = std.math.add(u64, p_offset, p_filesz) catch return error.Malformed;
             if (seg_end > data.len) return error.Malformed;
             ph_end = @max(ph_end, seg_end);
@@ -263,18 +320,32 @@ fn parseElf(gpa: Allocator, data: []const u8) ParseError!Parsed {
 
     const sections = try gpa.alloc(Shdr, shnum);
     for (sections, 0..) |*s, idx| {
-        const base: usize = @intCast(shoff + idx * 64);
-        s.* = .{
-            .name = rd(u32, data, base),
-            .shtype = rd(u32, data, base + 4),
-            .flags = rd(u64, data, base + 8),
-            .addr = rd(u64, data, base + 16),
-            .offset = rd(u64, data, base + 24),
-            .size = rd(u64, data, base + 32),
-            .link = rd(u32, data, base + 40),
-            .info = rd(u32, data, base + 44),
-            .addralign = rd(u64, data, base + 48),
-            .entsize = rd(u64, data, base + 56),
+        const base: usize = @intCast(shoff + idx * class.shEntSize());
+        s.* = switch (class) {
+            .elf32 => .{
+                .name = rd(u32, data, base),
+                .shtype = rd(u32, data, base + 4),
+                .flags = rd(u32, data, base + 8),
+                .addr = rd(u32, data, base + 12),
+                .offset = rd(u32, data, base + 16),
+                .size = rd(u32, data, base + 20),
+                .link = rd(u32, data, base + 24),
+                .info = rd(u32, data, base + 28),
+                .addralign = rd(u32, data, base + 32),
+                .entsize = rd(u32, data, base + 36),
+            },
+            .elf64 => .{
+                .name = rd(u32, data, base),
+                .shtype = rd(u32, data, base + 4),
+                .flags = rd(u64, data, base + 8),
+                .addr = rd(u64, data, base + 16),
+                .offset = rd(u64, data, base + 24),
+                .size = rd(u64, data, base + 32),
+                .link = rd(u32, data, base + 40),
+                .info = rd(u32, data, base + 44),
+                .addralign = rd(u64, data, base + 48),
+                .entsize = rd(u64, data, base + 56),
+            },
         };
         if (idx > 0 and s.shtype != SHT_NOBITS and s.shtype != SHT_NULL) {
             const end = std.math.add(u64, s.offset, s.size) catch return error.Malformed;
@@ -289,6 +360,7 @@ fn parseElf(gpa: Allocator, data: []const u8) ParseError!Parsed {
         "";
 
     return .{
+        .class = class,
         .shoff = @intCast(shoff),
         .shnum = shnum,
         .shstrndx = shstrndx,
@@ -322,6 +394,7 @@ const RewriteOptions = struct {
 /// section header table are appended.
 fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError![]u8 {
     const parsed = try parseElf(gpa, data);
+    const class = parsed.class;
     const sections = parsed.sections;
 
     // Decide which sections survive. Alloc sections are what the program
@@ -395,7 +468,8 @@ fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError
     // Rebuilt section header table.
     try padTo(gpa, &out, 8);
     const shoff = out.items.len;
-    try out.appendSlice(gpa, &([1]u8{0} ** 64)); // SHT_NULL entry
+    const null_entry = [1]u8{0} ** 64;
+    try out.appendSlice(gpa, null_entry[0..class.shEntSize()]); // SHT_NULL entry
     for (sections[1..], 1..) |s, idx| {
         if (!keep[idx]) continue;
         const link = if (s.link < sections.len) index_map[s.link] else 0;
@@ -406,7 +480,7 @@ fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError
             (if (s.info < sections.len) index_map[s.info] else 0)
         else
             s.info;
-        try appendShdr(gpa, &out, .{
+        try appendShdr(gpa, &out, class, .{
             .name = new_names[idx],
             .shtype = s.shtype,
             .flags = s.flags,
@@ -420,7 +494,7 @@ fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError
         });
     }
     if (opts.debuglink != null) {
-        try appendShdr(gpa, &out, .{
+        try appendShdr(gpa, &out, class, .{
             .name = debuglink_name,
             .shtype = SHT_PROGBITS,
             .flags = 0,
@@ -435,7 +509,7 @@ fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError
         next_index += 1;
     }
     const new_shstrndx: u16 = @intCast(next_index);
-    try appendShdr(gpa, &out, .{
+    try appendShdr(gpa, &out, class, .{
         .name = shstrtab_name,
         .shtype = SHT_STRTAB,
         .flags = 0,
@@ -449,9 +523,18 @@ fn rewriteElf(gpa: Allocator, data: []const u8, opts: RewriteOptions) ParseError
     });
     next_index += 1;
 
-    wr(u64, out.items, 40, shoff); // e_shoff
-    wr(u16, out.items, 60, next_index); // e_shnum
-    wr(u16, out.items, 62, new_shstrndx); // e_shstrndx
+    switch (class) {
+        .elf32 => {
+            wr(u32, out.items, 32, try cast32(shoff)); // e_shoff
+            wr(u16, out.items, 48, next_index); // e_shnum
+            wr(u16, out.items, 50, new_shstrndx); // e_shstrndx
+        },
+        .elf64 => {
+            wr(u64, out.items, 40, shoff); // e_shoff
+            wr(u16, out.items, 60, next_index); // e_shnum
+            wr(u16, out.items, 62, new_shstrndx); // e_shstrndx
+        },
+    }
 
     return out.toOwnedSlice(gpa);
 }
@@ -467,19 +550,43 @@ fn padTo(gpa: Allocator, out: *std.ArrayList(u8), alignment: usize) !void {
     while (out.items.len % alignment != 0) try out.append(gpa, 0);
 }
 
-fn appendShdr(gpa: Allocator, out: *std.ArrayList(u8), s: Shdr) !void {
-    var buf: [64]u8 = undefined;
-    std.mem.writeInt(u32, buf[0..4], s.name, .little);
-    std.mem.writeInt(u32, buf[4..8], s.shtype, .little);
-    std.mem.writeInt(u64, buf[8..16], s.flags, .little);
-    std.mem.writeInt(u64, buf[16..24], s.addr, .little);
-    std.mem.writeInt(u64, buf[24..32], s.offset, .little);
-    std.mem.writeInt(u64, buf[32..40], s.size, .little);
-    std.mem.writeInt(u32, buf[40..44], s.link, .little);
-    std.mem.writeInt(u32, buf[44..48], s.info, .little);
-    std.mem.writeInt(u64, buf[48..56], s.addralign, .little);
-    std.mem.writeInt(u64, buf[56..64], s.entsize, .little);
-    try out.appendSlice(gpa, &buf);
+fn appendShdr(gpa: Allocator, out: *std.ArrayList(u8), class: Class, s: Shdr) ParseError!void {
+    switch (class) {
+        .elf32 => {
+            var buf: [40]u8 = undefined;
+            std.mem.writeInt(u32, buf[0..4], s.name, .little);
+            std.mem.writeInt(u32, buf[4..8], s.shtype, .little);
+            std.mem.writeInt(u32, buf[8..12], try cast32(s.flags), .little);
+            std.mem.writeInt(u32, buf[12..16], try cast32(s.addr), .little);
+            std.mem.writeInt(u32, buf[16..20], try cast32(s.offset), .little);
+            std.mem.writeInt(u32, buf[20..24], try cast32(s.size), .little);
+            std.mem.writeInt(u32, buf[24..28], s.link, .little);
+            std.mem.writeInt(u32, buf[28..32], s.info, .little);
+            std.mem.writeInt(u32, buf[32..36], try cast32(s.addralign), .little);
+            std.mem.writeInt(u32, buf[36..40], try cast32(s.entsize), .little);
+            try out.appendSlice(gpa, &buf);
+        },
+        .elf64 => {
+            var buf: [64]u8 = undefined;
+            std.mem.writeInt(u32, buf[0..4], s.name, .little);
+            std.mem.writeInt(u32, buf[4..8], s.shtype, .little);
+            std.mem.writeInt(u64, buf[8..16], s.flags, .little);
+            std.mem.writeInt(u64, buf[16..24], s.addr, .little);
+            std.mem.writeInt(u64, buf[24..32], s.offset, .little);
+            std.mem.writeInt(u64, buf[32..40], s.size, .little);
+            std.mem.writeInt(u32, buf[40..44], s.link, .little);
+            std.mem.writeInt(u32, buf[44..48], s.info, .little);
+            std.mem.writeInt(u64, buf[48..56], s.addralign, .little);
+            std.mem.writeInt(u64, buf[56..64], s.entsize, .little);
+            try out.appendSlice(gpa, &buf);
+        },
+    }
+}
+
+/// ELF32 header fields are 32-bit; parsed inputs always fit (the file itself
+/// is capped at 4 GiB), so an overflow here means a malformed input.
+fn cast32(v: u64) ParseError!u32 {
+    return std.math.cast(u32, v) orelse error.Malformed;
 }
 
 fn rd(comptime T: type, data: []const u8, offset: usize) T {
@@ -512,23 +619,42 @@ const TestSection = struct {
     info: u32 = 0,
 };
 
-/// Builds an ELF64 LE image with the given sections; a SHT_NULL entry is
-/// prepended and a .shstrtab appended, so section i lands at index i+1.
-fn buildTestElf(gpa: Allocator, test_sections: []const TestSection) ![]u8 {
+/// Both classes are exercised by every rewrite test below.
+const test_classes = [_]Class{ .elf32, .elf64 };
+
+/// Builds a little-endian ELF image of the given class with the given
+/// sections; a SHT_NULL entry is prepended and a .shstrtab appended, so
+/// section i lands at index i+1.
+fn buildTestElf(gpa: Allocator, class: Class, test_sections: []const TestSection) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
-    try out.appendSlice(gpa, &([1]u8{0} ** 64));
+    const zeros = [1]u8{0} ** 64;
+    try out.appendSlice(gpa, zeros[0..class.ehSize()]);
     out.items[0] = 0x7f;
     out.items[1] = 'E';
     out.items[2] = 'L';
     out.items[3] = 'F';
-    out.items[4] = 2; // ELFCLASS64
+    out.items[4] = switch (class) {
+        .elf32 => 1, // ELFCLASS32
+        .elf64 => 2, // ELFCLASS64
+    };
     out.items[5] = 1; // ELFDATA2LSB
     out.items[6] = 1; // EV_CURRENT
     wr(u16, out.items, 16, 3); // e_type = ET_DYN
-    wr(u16, out.items, 18, 62); // e_machine = EM_X86_64
+    wr(u16, out.items, 18, @as(u16, switch (class) {
+        .elf32 => 40, // e_machine = EM_ARM
+        .elf64 => 62, // e_machine = EM_X86_64
+    }));
     wr(u32, out.items, 20, 1); // e_version
-    wr(u16, out.items, 52, 64); // e_ehsize
-    wr(u16, out.items, 58, 64); // e_shentsize
+    switch (class) {
+        .elf32 => {
+            wr(u16, out.items, 40, class.ehSize()); // e_ehsize
+            wr(u16, out.items, 46, class.shEntSize()); // e_shentsize
+        },
+        .elf64 => {
+            wr(u16, out.items, 52, class.ehSize()); // e_ehsize
+            wr(u16, out.items, 58, class.shEntSize()); // e_shentsize
+        },
+    }
 
     const offsets = try gpa.alloc(u64, test_sections.len);
     for (test_sections, offsets) |s, *offset| {
@@ -546,9 +672,9 @@ fn buildTestElf(gpa: Allocator, test_sections: []const TestSection) ![]u8 {
 
     try padTo(gpa, &out, 8);
     const shoff = out.items.len;
-    try out.appendSlice(gpa, &([1]u8{0} ** 64));
+    try out.appendSlice(gpa, zeros[0..class.shEntSize()]);
     for (test_sections, 0..) |s, idx| {
-        try appendShdr(gpa, &out, .{
+        try appendShdr(gpa, &out, class, .{
             .name = names[idx],
             .shtype = s.shtype,
             .flags = s.flags,
@@ -561,7 +687,7 @@ fn buildTestElf(gpa: Allocator, test_sections: []const TestSection) ![]u8 {
             .entsize = 0,
         });
     }
-    try appendShdr(gpa, &out, .{
+    try appendShdr(gpa, &out, class, .{
         .name = shstrtab_name,
         .shtype = SHT_STRTAB,
         .flags = 0,
@@ -574,9 +700,18 @@ fn buildTestElf(gpa: Allocator, test_sections: []const TestSection) ![]u8 {
         .entsize = 0,
     });
 
-    wr(u64, out.items, 40, shoff);
-    wr(u16, out.items, 60, test_sections.len + 2);
-    wr(u16, out.items, 62, test_sections.len + 1);
+    switch (class) {
+        .elf32 => {
+            wr(u32, out.items, 32, shoff);
+            wr(u16, out.items, 48, test_sections.len + 2);
+            wr(u16, out.items, 50, test_sections.len + 1);
+        },
+        .elf64 => {
+            wr(u64, out.items, 40, shoff);
+            wr(u16, out.items, 60, test_sections.len + 2);
+            wr(u16, out.items, 62, test_sections.len + 1);
+        },
+    }
     return out.toOwnedSlice(gpa);
 }
 
@@ -604,35 +739,38 @@ test "strip keeps alloc sections in place and drops the rest" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const original = try buildTestElf(arena, &test_layout);
-    const original_parsed = try parseElf(arena, original);
-    const original_text = findSection(original_parsed, ".text").?;
+    for (test_classes) |class| {
+        const original = try buildTestElf(arena, class, &test_layout);
+        const original_parsed = try parseElf(arena, original);
+        const original_text = findSection(original_parsed, ".text").?;
 
-    const stripped = try rewriteElf(arena, original, .{ .strip = true });
-    try testing.expect(stripped.len < original.len);
+        const stripped = try rewriteElf(arena, original, .{ .strip = true });
+        try testing.expect(stripped.len < original.len);
 
-    const parsed = try parseElf(arena, stripped);
-    // null + .text + .dynstr + .dynsym + rebuilt .shstrtab
-    try testing.expectEqual(@as(u16, 5), parsed.shnum);
-    try testing.expectEqual(@as(u16, 4), parsed.shstrndx);
-    try testing.expectEqual(null, findSection(parsed, ".symtab"));
-    try testing.expectEqual(null, findSection(parsed, ".strtab"));
-    try testing.expectEqual(null, findSection(parsed, ".debug_info"));
+        const parsed = try parseElf(arena, stripped);
+        try testing.expectEqual(class, parsed.class);
+        // null + .text + .dynstr + .dynsym + rebuilt .shstrtab
+        try testing.expectEqual(@as(u16, 5), parsed.shnum);
+        try testing.expectEqual(@as(u16, 4), parsed.shstrndx);
+        try testing.expectEqual(null, findSection(parsed, ".symtab"));
+        try testing.expectEqual(null, findSection(parsed, ".strtab"));
+        try testing.expectEqual(null, findSection(parsed, ".debug_info"));
 
-    // Alloc section contents must not have moved a byte.
-    const text = findSection(parsed, ".text").?;
-    try testing.expectEqual(original_text.offset, text.offset);
-    try testing.expectEqualSlices(
-        u8,
-        original[@intCast(original_text.offset)..@intCast(original_text.offset + original_text.size)],
-        stripped[@intCast(text.offset)..@intCast(text.offset + text.size)],
-    );
+        // Alloc section contents must not have moved a byte.
+        const text = findSection(parsed, ".text").?;
+        try testing.expectEqual(original_text.offset, text.offset);
+        try testing.expectEqualSlices(
+            u8,
+            original[@intCast(original_text.offset)..@intCast(original_text.offset + original_text.size)],
+            stripped[@intCast(text.offset)..@intCast(text.offset + text.size)],
+        );
 
-    // .dynsym's sh_link must be renumbered to .dynstr's new index (2), and
-    // its sh_info (a symbol index, not a section index) left alone.
-    const dynsym = findSection(parsed, ".dynsym").?;
-    try testing.expectEqual(@as(u32, 2), dynsym.link);
-    try testing.expectEqual(@as(u32, 1), dynsym.info);
+        // .dynsym's sh_link must be renumbered to .dynstr's new index (2), and
+        // its sh_info (a symbol index, not a section index) left alone.
+        const dynsym = findSection(parsed, ".dynsym").?;
+        try testing.expectEqual(@as(u32, 2), dynsym.link);
+        try testing.expectEqual(@as(u32, 1), dynsym.info);
+    }
 }
 
 test "strip is idempotent" {
@@ -640,10 +778,12 @@ test "strip is idempotent" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const original = try buildTestElf(arena, &test_layout);
-    const once = try rewriteElf(arena, original, .{ .strip = true });
-    const twice = try rewriteElf(arena, once, .{ .strip = true });
-    try testing.expectEqualSlices(u8, once, twice);
+    for (test_classes) |class| {
+        const original = try buildTestElf(arena, class, &test_layout);
+        const once = try rewriteElf(arena, original, .{ .strip = true });
+        const twice = try rewriteElf(arena, once, .{ .strip = true });
+        try testing.expectEqualSlices(u8, once, twice);
+    }
 }
 
 test "add-gnu-debuglink appends name, padding and crc" {
@@ -651,22 +791,24 @@ test "add-gnu-debuglink appends name, padding and crc" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const original = try buildTestElf(arena, &test_layout);
-    const stripped = try rewriteElf(arena, original, .{ .strip = true });
-    const linked = try rewriteElf(arena, stripped, .{
-        .strip = false,
-        .debuglink = .{ .basename = "Hello.dbg", .crc = 0xCBF43926 },
-    });
+    for (test_classes) |class| {
+        const original = try buildTestElf(arena, class, &test_layout);
+        const stripped = try rewriteElf(arena, original, .{ .strip = true });
+        const linked = try rewriteElf(arena, stripped, .{
+            .strip = false,
+            .debuglink = .{ .basename = "Hello.dbg", .crc = 0xCBF43926 },
+        });
 
-    const parsed = try parseElf(arena, linked);
-    // stripped sections + .gnu_debuglink + rebuilt .shstrtab
-    try testing.expectEqual(@as(u16, 6), parsed.shnum);
-    const debuglink = findSection(parsed, ".gnu_debuglink").?;
-    // "Hello.dbg\0" padded to 12, then 4 bytes of CRC.
-    try testing.expectEqual(@as(u64, 16), debuglink.size);
-    const contents = linked[@intCast(debuglink.offset)..@intCast(debuglink.offset + debuglink.size)];
-    try testing.expectEqualSlices(u8, "Hello.dbg\x00\x00\x00", contents[0..12]);
-    try testing.expectEqualSlices(u8, "\x26\x39\xf4\xcb", contents[12..16]);
+        const parsed = try parseElf(arena, linked);
+        // stripped sections + .gnu_debuglink + rebuilt .shstrtab
+        try testing.expectEqual(@as(u16, 6), parsed.shnum);
+        const debuglink = findSection(parsed, ".gnu_debuglink").?;
+        // "Hello.dbg\0" padded to 12, then 4 bytes of CRC.
+        try testing.expectEqual(@as(u64, 16), debuglink.size);
+        const contents = linked[@intCast(debuglink.offset)..@intCast(debuglink.offset + debuglink.size)];
+        try testing.expectEqualSlices(u8, "Hello.dbg\x00\x00\x00", contents[0..12]);
+        try testing.expectEqualSlices(u8, "\x26\x39\xf4\xcb", contents[12..16]);
+    }
 }
 
 test "add-gnu-debuglink replaces an existing debuglink" {
@@ -674,25 +816,27 @@ test "add-gnu-debuglink replaces an existing debuglink" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const original = try buildTestElf(arena, &test_layout);
-    const first = try rewriteElf(arena, original, .{
-        .strip = true,
-        .debuglink = .{ .basename = "old.dbg", .crc = 1 },
-    });
-    const second = try rewriteElf(arena, first, .{
-        .strip = false,
-        .debuglink = .{ .basename = "new.dbg", .crc = 2 },
-    });
+    for (test_classes) |class| {
+        const original = try buildTestElf(arena, class, &test_layout);
+        const first = try rewriteElf(arena, original, .{
+            .strip = true,
+            .debuglink = .{ .basename = "old.dbg", .crc = 1 },
+        });
+        const second = try rewriteElf(arena, first, .{
+            .strip = false,
+            .debuglink = .{ .basename = "new.dbg", .crc = 2 },
+        });
 
-    const parsed = try parseElf(arena, second);
-    var count: usize = 0;
-    for (parsed.sections[1..]) |s| {
-        if (std.mem.eql(u8, sectionName(parsed.shstrtab, s.name), ".gnu_debuglink")) count += 1;
+        const parsed = try parseElf(arena, second);
+        var count: usize = 0;
+        for (parsed.sections[1..]) |s| {
+            if (std.mem.eql(u8, sectionName(parsed.shstrtab, s.name), ".gnu_debuglink")) count += 1;
+        }
+        try testing.expectEqual(@as(usize, 1), count);
+        const debuglink = findSection(parsed, ".gnu_debuglink").?;
+        const contents = second[@intCast(debuglink.offset)..@intCast(debuglink.offset + debuglink.size)];
+        try testing.expectEqualSlices(u8, "new.dbg\x00", contents[0..8]);
     }
-    try testing.expectEqual(@as(usize, 1), count);
-    const debuglink = findSection(parsed, ".gnu_debuglink").?;
-    const contents = second[@intCast(debuglink.offset)..@intCast(debuglink.offset + debuglink.size)];
-    try testing.expectEqualSlices(u8, "new.dbg\x00", contents[0..8]);
 }
 
 test "strip combined with debuglink in one pass" {
@@ -700,15 +844,17 @@ test "strip combined with debuglink in one pass" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const original = try buildTestElf(arena, &test_layout);
-    const result = try rewriteElf(arena, original, .{
-        .strip = true,
-        .debuglink = .{ .basename = "a.dbg", .crc = 0 },
-    });
-    const parsed = try parseElf(arena, result);
-    try testing.expectEqual(@as(u16, 6), parsed.shnum);
-    try testing.expectEqual(null, findSection(parsed, ".symtab"));
-    try testing.expect(findSection(parsed, ".gnu_debuglink") != null);
+    for (test_classes) |class| {
+        const original = try buildTestElf(arena, class, &test_layout);
+        const result = try rewriteElf(arena, original, .{
+            .strip = true,
+            .debuglink = .{ .basename = "a.dbg", .crc = 0 },
+        });
+        const parsed = try parseElf(arena, result);
+        try testing.expectEqual(@as(u16, 6), parsed.shnum);
+        try testing.expectEqual(null, findSection(parsed, ".symtab"));
+        try testing.expect(findSection(parsed, ".gnu_debuglink") != null);
+    }
 }
 
 test "rejects non-ELF and unsupported ELF inputs" {
@@ -718,19 +864,27 @@ test "rejects non-ELF and unsupported ELF inputs" {
 
     try testing.expectError(error.NotElf, parseElf(arena, "not an elf file, not even close"));
 
-    const elf32 = try arena.dupe(u8, try buildTestElf(arena, &test_layout));
-    elf32[4] = 1; // ELFCLASS32
-    try testing.expectError(error.UnsupportedElf, parseElf(arena, elf32));
+    const bad_class = try arena.dupe(u8, try buildTestElf(arena, .elf64, &test_layout));
+    bad_class[4] = 3; // neither ELFCLASS32 nor ELFCLASS64
+    try testing.expectError(error.UnsupportedElf, parseElf(arena, bad_class));
 
-    const big_endian = try arena.dupe(u8, try buildTestElf(arena, &test_layout));
-    big_endian[5] = 2; // ELFDATA2MSB
-    try testing.expectError(error.UnsupportedElf, parseElf(arena, big_endian));
+    for (test_classes) |class| {
+        const big_endian = try arena.dupe(u8, try buildTestElf(arena, class, &test_layout));
+        big_endian[5] = 2; // ELFDATA2MSB
+        try testing.expectError(error.UnsupportedElf, parseElf(arena, big_endian));
 
-    const no_sections = try arena.dupe(u8, try buildTestElf(arena, &test_layout));
-    wr(u16, no_sections, 60, 0); // e_shnum = 0
-    try testing.expectError(error.NoSections, parseElf(arena, no_sections));
+        const no_sections = try arena.dupe(u8, try buildTestElf(arena, class, &test_layout));
+        switch (class) {
+            .elf32 => wr(u16, no_sections, 48, 0), // e_shnum = 0
+            .elf64 => wr(u16, no_sections, 60, 0),
+        }
+        try testing.expectError(error.NoSections, parseElf(arena, no_sections));
 
-    const truncated_shdrs = try arena.dupe(u8, try buildTestElf(arena, &test_layout));
-    wr(u64, truncated_shdrs, 40, truncated_shdrs.len - 32); // e_shoff past the end
-    try testing.expectError(error.Malformed, parseElf(arena, truncated_shdrs));
+        const truncated_shdrs = try arena.dupe(u8, try buildTestElf(arena, class, &test_layout));
+        switch (class) {
+            .elf32 => wr(u32, truncated_shdrs, 32, truncated_shdrs.len - 16), // e_shoff past the end
+            .elf64 => wr(u64, truncated_shdrs, 40, truncated_shdrs.len - 32),
+        }
+        try testing.expectError(error.Malformed, parseElf(arena, truncated_shdrs));
+    }
 }

--- a/test/Hello.csproj
+++ b/test/Hello.csproj
@@ -3,7 +3,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- net8.0 is the package's supported floor. The armv7 targets publish as
+         net9.0 instead: their ILCompiler runtime packs only ship for .NET 9+,
+         and net8.0 fails restore for those RIDs outright (NETSDK1203) - which
+         also rules out multi-targeting here. -->
     <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.EndsWith('-arm'))">net9.0</TargetFramework>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 


### PR DESCRIPTION
Closes #30.

Adds the armv7 Linux targets requested upstream in MichalStrehovsky/PublishAotCross#10.

## What's in here

**ELF32 support in the strip shim** (`objcopy_shim.zig`) — armv7 binaries are ELF32, which the shim's `llvm-objcopy` personality rejected, so the default `StripSymbols=true` pipeline would have failed for these targets. A `Class` enum now parameterizes the ELF/program/section header layouts; the rewrite logic itself stays class-agnostic (section fields remain u64 internally, narrowed through a checked cast on ELF32 writes). All rewrite tests run against both classes.

**Triple mapping** (`Crosscompile.targets`) — new `arm` arch mapping plus a `CrossCompileAbiSuffix` property carrying the hard-float suffix, producing `arm-linux-gnueabihf` / `arm-linux-musleabihf`.

**Test app** — stays `net8.0`, but switches to `net9.0` when the RID ends in `-arm`: ILCompiler runtime packs for armv7 only ship for .NET 9+, and `net8.0` fails restore for those RIDs outright (NETSDK1203), which also rules out multi-targeting.

**CI** — both RIDs build from all five hosts; runtime validation runs under QEMU in `linux/arm/v7` containers on the x64 runner (Debian for glibc since it needs an armhf userland, Alpine for musl — which is fully static thanks to zig's static musl linking). GitHub's hosted arm64 runners (Cobalt 100) dropped 32-bit AArch32 execution, so emulation is the only option there too.

## Verified locally (macOS arm64 host)

- Both RIDs publish through the default strip pipeline: stripped ELF32 armhf binaries, `.dbg` sidecar, `.gnu_debuglink` in place, `readelf`-clean section tables.
- Both print `Hello World` in `linux/arm/v7` Docker containers (Debian bookworm and Alpine 3.21).
- `zig test`: all 18 tests pass.
- Regression: `linux-x64` still publishes and runs with the refactored triple logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)