### PR TITLE
Automate Apple sysroot drift detection and ZigVersion bump checklist (#28, #29)

### DIFF
--- a/.github/workflows/apple-sysroot-drift.yml
+++ b/.github/workflows/apple-sysroot-drift.yml
@@ -1,0 +1,114 @@
+name: Apple sysroot drift
+
+# The bundled Apple linker stubs (src/apple-sysroot) cover exactly the symbols
+# the pinned .NET runtime packs reference. When a newer runtime pack references
+# a new Apple symbol, cross-compiled macOS links fail with an unresolved symbol
+# until the stubs are regenerated. This scheduled job catches that drift before
+# a user hits it: it regenerates the stubs against the *latest* stable + preview
+# packs and opens a PR when they differ, and separately canary-publishes for
+# osx-arm64 against the newest preview SDK so a genuine symbol gap turns the run
+# red even if the generator missed it.
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC. Runtime packs ship far less often than this.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Regenerate the stubs from the newest packs and open a PR on drift. Must run
+  # on macOS: the generator drives xcrun/nm and the local SDK's .tbd files.
+  drift:
+    runs-on: macos-latest
+    name: Regenerate stubs and check for drift
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      # .NET 10 SDK: the generator is a file-based app (dotnet run <file>.cs),
+      # which needs the .NET 10+ SDK.
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      # The generator drops symbols that zig's bundled libSystem stub already
+      # resolves, so the zig here must be the same upstream release the package
+      # ships (ZigVersion 0.16.0.2 in Crosscompile.targets == upstream 0.16.0).
+      # Keep this pinned version in step with ZigVersion on every bump.
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Regenerate Apple sysroot stubs (latest packs)
+        run: dotnet run eng/generate-apple-sysroot.cs -- --latest
+
+      - name: Check for drift
+        id: diff
+        run: |
+          if git diff --quiet -- src/apple-sysroot; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "No stub drift: the bundled stubs already cover the latest packs." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Apple sysroot stub drift detected :warning:"
+              echo ""
+              echo "The latest runtime packs reference symbols the bundled stubs do not."
+              echo '```diff'
+              git diff -- src/apple-sysroot
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Open pull request with regenerated stubs
+        if: steps.diff.outputs.drift == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/apple-sysroot-drift
+          commit-message: Regenerate Apple sysroot stubs for latest runtime packs
+          title: Regenerate Apple sysroot stubs (drift detected)
+          labels: automation
+          add-paths: src/apple-sysroot
+          body: |
+            The scheduled **Apple sysroot drift** job regenerated the bundled
+            linker stubs against the *latest* stable and preview runtime packs
+            (`--latest`) and they differ from what is checked in — a newer pack
+            references an Apple symbol the current stubs do not cover.
+
+            Review the diff, then consider bumping the pinned versions in
+            `PackVersions` (`eng/generate-apple-sysroot.cs`) to match, so a plain
+            `dotnet run eng/generate-apple-sysroot.cs` reproduces this output.
+
+  # Canary: publish the sample app for osx-arm64 against the newest preview SDK.
+  # A missing Apple symbol surfaces here as a link failure even if the generator
+  # above did not flag it. Targets the newest preview TFM so the newest preview
+  # ILCompiler pack is exercised; bump both when a new preview major ships.
+  canary:
+    runs-on: macos-latest
+    name: Canary publish (osx-arm64, newest preview SDK)
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Setup .NET (newest preview)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: preview
+
+      - name: Publish Hello for osx-arm64
+        run: |
+          dotnet publish test/Hello.csproj \
+            -r osx-arm64 \
+            -c Release \
+            -p:TargetFramework=net11.0 \
+            -p:StripSymbols=false \
+            -p:InvariantGlobalization=true \
+            --output artifacts/osx-arm64
+          test -f artifacts/osx-arm64/Hello

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -41,6 +41,24 @@ jobs:
           name: prebuilt-shims
           path: src/obj/shim/
 
+  # Run the Zig shim unit tests against the pinned toolchain. Encodes the first
+  # item of the ZigVersion bump checklist (docs/zig-version-bump.md) so a bump
+  # that breaks the shims against zig's churning std APIs fails here, on every
+  # PR, rather than in a downstream link. Uses the exact pinned ZigVersion via
+  # the Vezel toolset (see the TestShims target in AotAnywhere.nuproj).
+  shim-tests:
+    runs-on: ubuntu-latest
+    name: Zig shim unit tests
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+      - name: zig test the shims
+        run: dotnet build -t:TestShims src/AotAnywhere.nuproj
+
   # Generate a throwaway self-signed Developer ID-style certificate that the
   # build jobs use to exercise the signing integration. Generated once here:
   # rcodesign emits a PEM pair, and Ubuntu's OpenSSL converts it to a PKCS#12

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note that only browser downloads get the quarantine attribute; binaries fetched 
 
 ## Usage
 
-By default it relies on Zig provided by the unofficial [Vezel.Zig.Toolsets](https://github.com/vezel-dev/zig-toolsets) NuGet package. You can specify version of this package using the `ZigVersion` property. Instructions for using your own Zig binaries are near the end of this document.
+By default it relies on Zig provided by the unofficial [Vezel.Zig.Toolsets](https://github.com/vezel-dev/zig-toolsets) NuGet package. You can specify version of this package using the `ZigVersion` property. Instructions for using your own Zig binaries are near the end of this document. (Maintainers: bumping the pinned `ZigVersion` follows the [ZigVersion bump checklist](docs/zig-version-bump.md).)
 
 1. To your project that is already using Native AOT, add a reference to the [`StuDev.AotAnywhere`](https://www.nuget.org/packages/StuDev.AotAnywhere) NuGet package:
 

--- a/docs/zig-version-bump.md
+++ b/docs/zig-version-bump.md
@@ -1,0 +1,55 @@
+# Bumping ZigVersion
+
+`ZigVersion` (the [Vezel.Zig.Toolsets](https://github.com/vezel-dev/zig-toolsets)
+package version) is pinned in two places that **must stay in sync**:
+
+- `src/Crosscompile.targets`
+- `src/AotAnywhere.nuproj`
+
+Zig has repeatedly changed behaviour relevant to this package between releases,
+so every bump goes through the checklist below. Most of it is enforced
+automatically — the notes say where.
+
+## Checklist
+
+- [ ] **Both pins updated and in sync.** Update the `<ZigVersion>` default in
+      *both* files above. Renovate opens the bump PR (see
+      [Automation](#automation)); confirm it touched both.
+
+- [ ] **`zig test` the shims passes with the new toolchain.** The shim sources
+      (`clang_shim.zig`, `objcopy_shim.zig`) must still compile and pass — zig's
+      std APIs churn between releases.
+      *Automated:* the `shim-tests` job in `cross-platform-validation.yml` runs
+      `dotnet build -t:TestShims src/AotAnywhere.nuproj` on every PR. Run the
+      same command locally to check before pushing.
+
+- [ ] **Prebuilt shims rebuild for all host RIDs.** `BuildClangShims` in
+      `AotAnywhere.nuproj` cross-compiles a shim for every host RID from one
+      machine.
+      *Automated:* the `pack` job builds the package (all host shims) on every
+      PR.
+
+- [ ] **Re-test the aarch64-windows codegen bug.** zig 0.16's aarch64-windows
+      `build-exe` produces a shim that crashes at startup, so `win-arm64` is
+      omitted as a host (`ShimTarget` in the nuproj, the CI matrix, and the
+      README all leave it out). If a newer zig fixes it, re-add `win-arm64` to
+      all three and confirm a cross-compiled shim runs on real arm64 Windows.
+
+- [ ] **Re-check `zig objcopy` ELF-to-ELF support.** The bundled `objcopy_shim`
+      exists because `zig objcopy` cannot strip ELF-to-ELF (issue #27). If a
+      newer zig gains it, the shim may be simplifiable.
+
+- [ ] **Full cross-platform validation matrix green.** The `build` and
+      `validate` jobs in `cross-platform-validation.yml` exercise every host ×
+      target combination and run the resulting binaries.
+      *Automated:* runs on every PR.
+
+## Automation
+
+- **Renovate** (`renovate.json`) watches `Vezel.Zig.Toolsets.*` on nuget.org and
+  opens a PR that bumps the `<ZigVersion>` value in both files. The PR body
+  carries this checklist.
+- The **CI already covers most of the checklist** on any PR (`shim-tests`,
+  `pack`, `build`, `validate`). The manual items are the ones a green run cannot
+  prove: the win-arm64 codegen and `zig objcopy` re-checks, which only matter
+  when deciding whether a bump lets us *remove* a workaround.

--- a/eng/generate-apple-sysroot.cs
+++ b/eng/generate-apple-sysroot.cs
@@ -25,13 +25,21 @@
 // result. It is a .NET file-based app, so run it directly with:
 //
 //   dotnet run eng/generate-apple-sysroot.cs
+//
+// Pass --latest to resolve the newest patch/preview of each pinned lineage from
+// nuget.org instead of the pinned versions (drops the need to hand-bump the
+// pins before checking for drift). The scheduled drift-detection workflow runs
+// this mode and opens a PR when the regenerated stubs differ:
+//
+//   dotnet run eng/generate-apple-sysroot.cs -- --latest
 
 using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
-await Generator.RunAsync();
+await Generator.RunAsync(args);
 
 static partial class Generator
 {
@@ -138,19 +146,114 @@ static partial class Generator
         return null!;
     }
 
+    static string PackId(string family, string rid) => family == "ilcompiler"
+        ? $"runtime.{rid}.microsoft.dotnet.ilcompiler"
+        : $"microsoft.netcore.app.runtime.nativeaot.{rid}";
+
     // (pack-id, version, arch) triples with their nuget.org download URL.
-    static IEnumerable<(string Pack, string Version, string Rid, string Url)> PackUrls()
+    static IEnumerable<(string Pack, string Version, string Rid, string Url)> PackUrls(
+        (string Family, string[] Versions)[] packVersions)
     {
-        foreach (var (family, versions) in PackVersions)
+        foreach (var (family, versions) in packVersions)
             foreach (var version in versions)
                 foreach (var rid in Rids)
                 {
-                    string pack = family == "ilcompiler"
-                        ? $"runtime.{rid}.microsoft.dotnet.ilcompiler"
-                        : $"microsoft.netcore.app.runtime.nativeaot.{rid}";
+                    string pack = PackId(family, rid);
                     string url = $"https://api.nuget.org/v3-flatcontainer/{pack}/{version}/{pack}.{version}.nupkg";
                     yield return (pack, version, rid, url);
                 }
+    }
+
+    // --- "latest" version resolution (drift detection) ---------------------
+
+    // Replace each pinned version with the newest version nuget.org offers in
+    // the same major and prerelease lineage. A pinned stable 10.0.9 tracks the
+    // newest stable 10.x; a pinned preview 11.0.0-preview.5.* tracks the newest
+    // 11.x preview. This is what the scheduled drift job runs with (--latest):
+    // it surfaces new Apple symbols pulled in by fresh patches/previews without
+    // needing the pinned list to be hand-bumped first. Whole new majors (e.g. a
+    // future net12) are intentionally NOT auto-discovered - that is a deliberate
+    // support decision, handled by editing PackVersions.
+    static async Task<(string Family, string[] Versions)[]> ResolveLatestAsync()
+    {
+        Console.WriteLine("Resolving latest runtime pack versions from nuget.org (--latest):");
+        var resolved = new List<(string, string[])>();
+        foreach (var (family, versions) in PackVersions)
+        {
+            // osx-arm64 and osx-x64 packs ship in lockstep; query one lineage.
+            string pack = PackId(family, "osx-arm64");
+            var available = await FetchIndexVersionsAsync(pack);
+            var picked = new List<string>();
+            foreach (var pinned in versions)
+            {
+                int major = Major(pinned);
+                bool preview = IsPrerelease(pinned);
+                string newest = available
+                    .Where(v => Major(v) == major && IsPrerelease(v) == preview)
+                    .OrderBy(v => v, VersionComparer)
+                    .LastOrDefault() ?? pinned;
+                if (newest != pinned)
+                    Console.WriteLine($"  {pack}: {pinned} -> {newest}");
+                else
+                    Console.WriteLine($"  {pack}: {pinned} (already newest)");
+                picked.Add(newest);
+            }
+            resolved.Add((family, picked.Distinct().ToArray()));
+        }
+        return resolved.ToArray();
+    }
+
+    static async Task<List<string>> FetchIndexVersionsAsync(string pack)
+    {
+        string url = $"https://api.nuget.org/v3-flatcontainer/{pack}/index.json";
+        using var doc = JsonDocument.Parse(await Http.GetStringAsync(url));
+        return doc.RootElement.GetProperty("versions")
+            .EnumerateArray().Select(e => e.GetString()!).ToList();
+    }
+
+    static int Major(string version) =>
+        int.Parse(version.Split('.', 2)[0]);
+
+    static bool IsPrerelease(string version) => version.Contains('-');
+
+    // SemVer-style ordering: compare release parts numerically, a release
+    // outranks any prerelease of the same numbers, and prerelease identifiers
+    // compare dot-by-dot (numeric numerically, otherwise ordinal).
+    static readonly IComparer<string> VersionComparer =
+        Comparer<string>.Create(static (a, b) =>
+        {
+            var (relA, preA) = SplitVersion(a);
+            var (relB, preB) = SplitVersion(b);
+            int n = Math.Max(relA.Length, relB.Length);
+            for (int i = 0; i < n; i++)
+            {
+                int va = i < relA.Length ? relA[i] : 0;
+                int vb = i < relB.Length ? relB[i] : 0;
+                if (va != vb) return va.CompareTo(vb);
+            }
+            if (preA.Length == 0 && preB.Length == 0) return 0;
+            if (preA.Length == 0) return 1;  // release > prerelease
+            if (preB.Length == 0) return -1;
+            int m = Math.Min(preA.Length, preB.Length);
+            for (int i = 0; i < m; i++)
+            {
+                bool na = int.TryParse(preA[i], out int ia);
+                bool nb = int.TryParse(preB[i], out int ib);
+                int c = na && nb ? ia.CompareTo(ib)
+                    : na ? -1 : nb ? 1
+                    : string.CompareOrdinal(preA[i], preB[i]);
+                if (c != 0) return c;
+            }
+            return preA.Length.CompareTo(preB.Length);
+        });
+
+    static (int[] Release, string[] Prerelease) SplitVersion(string version)
+    {
+        int dash = version.IndexOf('-');
+        string release = dash < 0 ? version : version[..dash];
+        string[] pre = dash < 0 ? [] : version[(dash + 1)..].Split('.');
+        int[] rel = release.Split('.').Select(int.Parse).ToArray();
+        return (rel, pre);
     }
 
     // Download a pack (cached) and extract its .a/.o members. Returns a dir.
@@ -344,8 +447,15 @@ static partial class Generator
 
     // --- driver ------------------------------------------------------------
 
-    public static async Task RunAsync()
+    public static async Task RunAsync(string[] args)
     {
+        // --latest: resolve the newest patch/preview of each pinned lineage from
+        // nuget.org instead of the pinned PackVersions (used by the scheduled
+        // drift-detection workflow). Default: use exactly the pinned versions.
+        var packVersions = args.Contains("--latest")
+            ? await ResolveLatestAsync()
+            : PackVersions;
+
         string sdk = SdkPath();
         Console.WriteLine($"SDK: {sdk}");
         string zigTbd = ZigLibSystemTbd();
@@ -365,7 +475,7 @@ static partial class Generator
         // needed = union over packs of (undefined - defined-within-the-same-pack)
         var needed = new HashSet<string>();
         Console.WriteLine("Collecting undefined symbols from runtime packs:");
-        foreach (var (pack, version, rid, url) in PackUrls())
+        foreach (var (pack, version, rid, url) in PackUrls(packVersions))
         {
             string directory = await FetchNativeMembersAsync(pack, version, url);
             var undefined = NmSymbols(directory, "-u");

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump the ZigVersion (Vezel.Zig.Toolsets) pin in both files that must stay in sync",
+      "managerFilePatterns": [
+        "/^src/Crosscompile\\.targets$/",
+        "/^src/AotAnywhere\\.nuproj$/"
+      ],
+      "matchStrings": [
+        "<ZigVersion[^>]*>(?<currentValue>[^<]+)</ZigVersion>"
+      ],
+      "datasourceTemplate": "nuget",
+      "depNameTemplate": "Vezel.Zig.Toolsets.linux-x64"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "Vezel.Zig.Toolsets.linux-x64"
+      ],
+      "groupName": "ZigVersion",
+      "commitMessageTopic": "ZigVersion (Zig toolchain)",
+      "prBodyNotes": [
+        ":warning: Zig releases change behaviour relevant to this package. Work through the **[ZigVersion bump checklist](docs/zig-version-bump.md)** before merging — in particular the win-arm64 codegen and `zig objcopy` re-checks that a green CI run cannot prove."
+      ]
+    }
+  ]
+}

--- a/src/AotAnywhere.nuproj
+++ b/src/AotAnywhere.nuproj
@@ -71,10 +71,10 @@
     <ShimTarget Include="linux-arm64" Triple="aarch64-linux-musl" Exe="clang" />
   </ItemGroup>
 
-  <Target Name="BuildClangShims"
-          Inputs="clang_shim.zig;objcopy_shim.zig;@(ShimTarget)"
-          Outputs="@(ShimTarget->'$(ShimIntermediateDir)%(Identity)/%(Exe)')">
-
+  <!-- Resolve the pack-host zig from the Vezel toolset package. Shared by
+       BuildClangShims (cross-compiles the shims) and TestShims (runs the shim
+       unit tests) so both use the exact pinned ZigVersion. -->
+  <Target Name="_ResolveZigForShims">
     <PropertyGroup>
       <_ZigTools Condition="$(PackHostRuntimeIdentifier.StartsWith('win-x86'))">$(PkgVezel_Zig_Toolsets_win-x86)/tools</_ZigTools>
       <_ZigTools Condition="$(PackHostRuntimeIdentifier.StartsWith('win-x64'))">$(PkgVezel_Zig_Toolsets_win-x64)/tools</_ZigTools>
@@ -89,6 +89,12 @@
 
     <Error Condition="'$(_ZigTools)' == ''"
            Text="No Vezel.Zig.Toolsets package for pack host '$(PackHostRuntimeIdentifier)'. Set PackHostRuntimeIdentifier to a supported host RID." />
+  </Target>
+
+  <Target Name="BuildClangShims"
+          DependsOnTargets="_ResolveZigForShims"
+          Inputs="clang_shim.zig;objcopy_shim.zig;@(ShimTarget)"
+          Outputs="@(ShimTarget->'$(ShimIntermediateDir)%(Identity)/%(Exe)')">
 
     <MakeDir Directories="$(ShimIntermediateDir)%(ShimTarget.Identity)" />
 
@@ -97,6 +103,21 @@
     <Exec Command="&quot;$(_ZigExe)&quot; build-exe -O ReleaseSafe -fstrip -target %(ShimTarget.Triple) -femit-bin=&quot;$(ShimIntermediateDir)%(ShimTarget.Identity)/%(ShimTarget.Exe)&quot; &quot;$(MSBuildProjectDirectory)/clang_shim.zig&quot;" />
 
   </Target>
+
+  <!-- Run the shim unit tests against the pinned zig. Encodes the ZigVersion
+       bump checklist item "zig test the shims" (see docs/zig-version-bump.md):
+       the shim sources must compile and pass with the pinned toolchain, and
+       zig's std APIs churn between releases. Invoked in CI on every PR via
+       `dotnet build -t:TestShims src/AotAnywhere.nuproj`. -->
+  <Target Name="TestShims" DependsOnTargets="_ResolveZigForShims">
+    <Message Importance="high" Text="zig test %(ShimSource.Identity) (zig $(ZigVersion))" />
+    <Exec Command="&quot;$(_ZigExe)&quot; test &quot;$(MSBuildProjectDirectory)/%(ShimSource.Identity)&quot;" />
+  </Target>
+
+  <ItemGroup>
+    <ShimSource Include="clang_shim.zig" />
+    <ShimSource Include="objcopy_shim.zig" />
+  </ItemGroup>
 
   <!-- Register the shims for packing in a separate, always-run target: doing it
        inside BuildClangShims would drop them from the package whenever that


### PR DESCRIPTION
Closes #28 and #29.

For **#28**, adds a `--latest` mode to `eng/generate-apple-sysroot.cs` that resolves the newest patch/preview runtime packs from nuget.org, and a weekly workflow that regenerates the Apple linker stubs, opens a PR when they drift, and canary-publishes the sample for `osx-arm64` against the newest preview SDK so a symbol gap turns the run red. For **#29**, adds a `TestShims` MSBuild target that runs `zig test` on both shims with the pinned toolchain and wires it into CI on every PR, documents the `ZigVersion` bump checklist in `docs/zig-version-bump.md`, and adds a Renovate config that watches `Vezel.Zig.Toolsets` and attaches the checklist to bump PRs. The `--latest` generator run, both new MSBuild targets, and all YAML/JSON configs were validated locally (all 25 shim tests pass; no stub drift today). I deliberately ignored the malware link posted in a comment on #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)