### PR TITLE
Silence Renovate NuGet lookup warning for interpolated Zig package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,16 @@
   ],
   "packageRules": [
     {
+      "description": "The PackageReference in Crosscompile.targets uses an unexpanded MSBuild property ($(HostRuntimeIdentifier)) as the package name; the built-in NuGet manager cannot resolve it (the custom manager above handles the real bump), so ignore it.",
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "/^Vezel\\.Zig\\.Toolsets\\.\\$\\(HostRuntimeIdentifier\\)$/"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "Vezel.Zig.Toolsets.linux-x64"
       ],


### PR DESCRIPTION
Renovate's built-in NuGet manager reads the `PackageReference` in `src/Crosscompile.targets` literally and tries to resolve `Vezel.Zig.Toolsets.$(HostRuntimeIdentifier)` — an unexpanded MSBuild property — which returns `no-result`. This adds a `packageRules` entry (scoped to the `nuget` manager) that disables that interpolated dependency, using a regex matcher since the name contains glob metacharacters. The custom manager already drives the real `ZigVersion` bump via `Vezel.Zig.Toolsets.linux-x64`, so no version tracking is lost.