### PR TITLE
Add tag-triggered NuGet release workflow with trusted publishing (#26)

### DIFF
--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ master ]
   workflow_dispatch:
+  # Lets the release workflow (publish.yml) require the full matrix green on the
+  # tagged commit before publishing.
+  workflow_call:
 
 env:
   # rcodesign (https://github.com/indygreg/apple-platform-rs) generates the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish to NuGet
+
+# Keyed off the version tag that main.yml's release dispatch pushes, so releases
+# stay one-button: dispatch main.yml with a version -> it tags v<version> ->
+# this workflow validates, packs, and publishes StuDev.AotAnywhere to nuget.org.
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  # Require the full cross-platform matrix green on the tagged commit before we
+  # publish anything. Reusable via workflow_call (see cross-platform-validation.yml).
+  validate:
+    uses: ./.github/workflows/cross-platform-validation.yml
+
+  publish:
+    needs: validate
+    # windows-latest is the only host whose zig cross-compiles all six prebuilt
+    # shims (arm64-Windows zig 0.16 build-exe is broken; see the nuproj), so it
+    # is the one host that can pack the complete package. Matches the shim
+    # (`pack`) job in cross-platform-validation.yml.
+    runs-on: windows-latest
+    # Trusted publishing: NuGet/login mints a short-lived key from the OIDC
+    # token instead of a long-lived nuget.org API key. contents: write is for
+    # attaching the .nupkg to the GitHub release.
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Pack
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "Packing StuDev.AotAnywhere $version"
+          dotnet build -t:Pack src/AotAnywhere.nuproj -p:Version="$version"
+          nupkg=$(find src/bin -name "StuDev.AotAnywhere.$version.nupkg" | head -1)
+          if [ -z "$nupkg" ]; then echo "::error::packed nupkg not found for $version" >&2; exit 1; fi
+          mkdir -p artifacts
+          cp "$nupkg" artifacts/
+
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}  # nuget.org profile name, NOT email
+
+      - name: Push to NuGet
+        shell: bash
+        run: |
+          dotnet nuget push artifacts/*.nupkg \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      # Attach the published .nupkg to a GitHub release for traceability. Guarded
+      # so a re-run of a partially-completed publish updates the release instead
+      # of failing with a 422 already_exists.
+      - name: Attach package to GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" artifacts/*.nupkg --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" artifacts/*.nupkg --generate-notes
+          fi


### PR DESCRIPTION
Adds `publish.yml`, a tag-triggered (`v*`) release workflow that publishes `StuDev.AotAnywhere` to nuget.org via **trusted publishing** — `NuGet/login@v1` mints a short-lived OIDC key (`id-token: write`), so there is no long-lived API key to store or rotate. It first runs the full cross-platform validation matrix on the tagged commit, then packs on `windows-latest` (the only host whose zig cross-compiles all six shims) with `-p:Version=<tag>`, pushes with `--skip-duplicate`, and attaches the `.nupkg` to the GitHub release for traceability. `cross-platform-validation.yml` gains a `workflow_call:` trigger so the release can gate on it. This completes #26; the existing one-button flow is preserved (dispatch `main.yml` → it tags `v<version>` → this workflow publishes).

One-time setup before the first publish: add a Trusted Publishers policy on nuget.org (owner `slang25`, repo `AotAnywhere`, workflow `publish.yml`, environment `release`, prefix `StuDev.*`) and create a GitHub `release` environment with a `NUGET_USER` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)