### PR TITLE
Isolate NuGet folders per parallel group to fix concurrent-restore race

### DIFF
--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -17,7 +17,24 @@ export PATH="$PWD/.rcodesign:$PATH"
 
 # The target groups run concurrently (parallel steps in
 # cross-platform-validation.yml), so up to three dotnet processes run at once on
-# this host. coreclr derives its shared-memory dir from $TMPDIR
+# this host. Anything they share and write to races; give each invocation its
+# own copy. The group id keys every per-invocation path below.
+group_id="${host_name}-$(echo "$2" | tr ',' '_')"
+
+# NuGet's global-packages folder (~/.nuget/packages) and HTTP cache are shared,
+# and concurrent restores race extracting the same packages into them - notably
+# the large Vezel zig toolset, which macOS re-extracts even when already present
+# - producing "Directory not empty", missing-temp-file, and http-cache
+# `.dat-new` errors. Serial pre-warming doesn't help (macOS still re-extracts),
+# so isolate the folders per group instead: nothing shared, no collision.
+# $RUNNER_TEMP is a native path on every host, so this is safe on Windows too,
+# and the cache step archives the whole $RUNNER_TEMP/nuget tree.
+nuget_root="${RUNNER_TEMP:-/tmp}/nuget/$group_id"
+export NUGET_PACKAGES="$nuget_root/packages"
+export NUGET_HTTP_CACHE_PATH="$nuget_root/http-cache"
+mkdir -p "$NUGET_PACKAGES" "$NUGET_HTTP_CACHE_PATH"
+
+# coreclr derives its shared-memory dir from $TMPDIR
 # ($TMPDIR/.dotnet/shm/session<id>, keyed on the login session, not the PID), so
 # the concurrent processes collide creating it and one fails with
 # `mkdir(...session<id>) == -1; errno == EEXIST`. Give each invocation its own
@@ -26,7 +43,7 @@ export PATH="$PWD/.rcodesign:$PATH"
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) ;;
   *)
-    TMPDIR="${RUNNER_TEMP:-/tmp}/dotnet-tmp/${host_name}-$(echo "$2" | tr ',' '_')"
+    TMPDIR="${RUNNER_TEMP:-/tmp}/dotnet-tmp/$group_id"
     mkdir -p "$TMPDIR"
     export TMPDIR
     ;;

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -158,11 +158,13 @@ jobs:
 
       # The publishes below restore the Vezel zig toolset for this host plus
       # ILCompiler/runtime packs for all eight target RIDs - several hundred
-      # MB from nuget.org on every run without this cache.
+      # MB from nuget.org on every run without this cache. build-targets.sh
+      # gives each concurrent group its own NuGet folders under
+      # $RUNNER_TEMP/nuget (see below), so cache that whole tree.
       - name: Cache NuGet packages
         uses: actions/cache@v6
         with:
-          path: ~/.nuget/packages
+          path: ${{ runner.temp }}/nuget
           key: nuget-publish-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/AotAnywhere.nuproj', 'src/Crosscompile.targets', 'test/Hello.csproj') }}
           restore-keys: |
             nuget-publish-${{ runner.os }}-${{ runner.arch }}-


### PR DESCRIPTION
Third concurrency bug from PR #42's parallel-publish refactor (after the macOS `sign_args` and `.dotnet/shm` fixes in #43). The three concurrent publish groups race extracting shared packages — chiefly the large Vezel **zig toolset** — into the shared `~/.nuget/packages` and HTTP cache, corrupting them (`Directory not empty`, missing temp files, `http-cache/...dat-new`). macOS re-extracts that toolset even when it's already present.

**Approaches tried and rejected:**
- *Serial warm-up into the shared cache* — fixed Linux, but macOS re-extracts during the parallel publish, so it still collided.
- *Serial restore + parallel `dotnet publish --no-restore`* — would keep one shared cache, but `--no-restore` is incompatible with AotAnywhere's targets: zig drops off `PATH` (clang shim → exit 127) and the armv7/net9 restore graph doesn't match the publish (`NETSDK1005`).

**This fix:** give each concurrent group its own `NUGET_PACKAGES` and `NUGET_HTTP_CACHE_PATH` under `$RUNNER_TEMP/nuget` — the groups share nothing, so a collision is structurally impossible. Speed impact is modest, not 3×: the three groups have **disjoint** RID sets, so the big per-RID ILCompiler runtime packs aren't duplicated; only the shared packages (zig toolset, compiler, SDK refs) are. The whole tree is cached, so warm runs stay fast. Keeps the per-group `TMPDIR` isolation from #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)