### PR TITLE
Warm coreclr shared-memory dir to fix concurrent-dotnet EEXIST race

### DIFF
--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -15,12 +15,10 @@ IFS=',' read -ra TARGET_ARRAY <<< "$2"
 # rcodesign is invoked by the SignMacOsBinary target for osx-x64
 export PATH="$PWD/.rcodesign:$PATH"
 
-# The target groups run concurrently (parallel steps in
+# This script runs concurrently (three parallel target groups in
 # cross-platform-validation.yml), so up to three dotnet processes run at once on
-# this host. Anything they share and write to races; give each invocation its
-# own copy. The group id keys every per-invocation path below.
-group_id="${host_name}-$(echo "$2" | tr ',' '_')"
-
+# this host. Anything they share and write to races.
+#
 # NuGet's global-packages folder (~/.nuget/packages) and HTTP cache are shared,
 # and concurrent restores race extracting the same packages into them - notably
 # the large Vezel zig toolset, which macOS re-extracts even when already present
@@ -29,25 +27,16 @@ group_id="${host_name}-$(echo "$2" | tr ',' '_')"
 # so isolate the folders per group instead: nothing shared, no collision.
 # $RUNNER_TEMP is a native path on every host, so this is safe on Windows too,
 # and the cache step archives the whole $RUNNER_TEMP/nuget tree.
+#
+# (coreclr's other shared resource, its /tmp/.dotnet/shm/session<id> dir, is a
+# FIXED path that TMPDIR does NOT relocate, so it can't be isolated the same
+# way; the workflow's "Warm coreclr shared memory" step creates it serially,
+# up front, so these concurrent processes never race to mkdir it.)
+group_id="${host_name}-$(echo "$2" | tr ',' '_')"
 nuget_root="${RUNNER_TEMP:-/tmp}/nuget/$group_id"
 export NUGET_PACKAGES="$nuget_root/packages"
 export NUGET_HTTP_CACHE_PATH="$nuget_root/http-cache"
 mkdir -p "$NUGET_PACKAGES" "$NUGET_HTTP_CACHE_PATH"
-
-# coreclr derives its shared-memory dir from $TMPDIR
-# ($TMPDIR/.dotnet/shm/session<id>, keyed on the login session, not the PID), so
-# the concurrent processes collide creating it and one fails with
-# `mkdir(...session<id>) == -1; errno == EEXIST`. Give each invocation its own
-# TMPDIR so the shm trees don't overlap. Skipped on Windows: it has no such shm
-# path, and an MSYS-style TMPDIR wouldn't survive the bash -> dotnet boundary.
-case "$(uname -s)" in
-  MINGW*|MSYS*|CYGWIN*) ;;
-  *)
-    TMPDIR="${RUNNER_TEMP:-/tmp}/dotnet-tmp/$group_id"
-    mkdir -p "$TMPDIR"
-    export TMPDIR
-    ;;
-esac
 
 build_success=true
 

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -210,6 +210,18 @@ jobs:
           mv apple-codesign-*/rcodesign* .
           ./rcodesign --version
 
+      # coreclr keeps its cross-process named mutexes in a per-login-session dir,
+      # /tmp/.dotnet/shm/session<id>, at a FIXED path TMPDIR can't relocate. When
+      # that dir doesn't exist yet, concurrent dotnet processes race to mkdir it
+      # and the loser dies with `errno == EEXIST` ("NuGet-Migrations") - which is
+      # exactly what the three parallel publish groups below would hit on a cold
+      # runner. Run one dotnet up front (a no-RID restore creates the mutex, and
+      # thus the session dir); the concurrent groups then find it and skip the
+      # racy mkdir. No-op on Windows, which has no such shm dir.
+      - name: Warm coreclr shared memory
+        shell: bash
+        run: dotnet restore test/Hello.csproj
+
       # The eight publishes are independent, so run them as three concurrent
       # streams (Actions parallel steps). Three streams - not eight - because
       # the hosted runners have 3-4 cores and ILC is memory-hungry; grouping


### PR DESCRIPTION
Master's CI is still red after #44 — a **different** race: `System.IO.IOException ... 'NuGet-Migrations' ... mkdir("/tmp/.dotnet/shm/session<id>") == -1; errno == EEXIST`.

This is the coreclr shared-memory race that #43 tried to fix by relocating `$TMPDIR` per group. **That never worked** — I verified locally that coreclr's shm dir is a *fixed* `/tmp/.dotnet/shm/session<id>` that `TMPDIR` does not move. #43 just happened to win the race until master's #44 run lost it (a genuinely flaky, non-deterministic failure).

The real race: concurrent `dotnet` processes both `mkdir` that per-login-session dir when it's cold, and the loser dies with `EEXIST`. **Fix:** create it once, serially, with a no-RID `dotnet restore` before the parallel publishes (restore makes the `NuGet-Migrations` mutex → the session dir); the concurrent groups then find it and skip the racy mkdir. Drops the ineffective per-group `TMPDIR`; keeps the per-group NuGet folder isolation from #44 (that one is real and load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)