### PR TITLE
Add Windows targets: cross-compile win-x64/win-arm64 from Linux/macOS

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -7,6 +7,7 @@ This document provides development guidance for the AotAnywhere repository, spec
 AotAnywhere is a NuGet package that enables cross-compilation for .NET Native AOT applications using Zig as the linker/sysroot. The primary components developers work with are:
 
 - `src/clang_shim.zig` - Zig source for the clang wrapper. The MSBuild targets compile it on demand with the bundled zig toolchain (`CompileClangShim` target), so the same shim runs on every host OS. It rewrites clang arguments and forwards the invocation to `zig cc`. The source must compile with the zig version pinned by `$(ZigVersion)` in `Crosscompile.targets`; bumping that version may require updating the shim for zig std library changes.
+- `src/link_shim.zig` - the `link` personality of the same multi-call binary, used when targeting Windows (`win-x64`, `win-arm64`) from a Linux/macOS host. It expands the MSVC-style `link @rsp` response file the ILC targets write, translates the options to GNU spellings, injects a glue C source bridging the MSVC-built NativeAOT runtime libs onto the MinGW CRT (GS-cookie helpers, MSVC-mangled operator new/delete, arm64 `_Interlocked*`, `_fltused`, `__isa_available`, empty stub archives for `LIBCMT`/`OLDNAMES`/`libcpmt`/`uuid`), and forwards to `zig cc -target <arch>-windows-gnu`.
 - `src/Crosscompile.targets` - MSBuild targets that configure Zig toolchain and compile the shim
 - `src/StuDev.AotAnywhere.targets` - Main MSBuild integration
 - `src/apple-sysroot/` - Minimal, self-generated Apple linker stubs (`.tbd`) used when cross-compiling to macOS from Windows/Linux. Regenerated with `eng/generate-apple-sysroot.cs` (requires macOS with Xcode and zig on PATH); update `PackVersions` in that script when new .NET versions ship. `Crosscompile.targets` points the shim at it via the `AOTANYWHERE_APPLE_SYSROOT` environment variable unless the user supplies their own sysroot.
@@ -106,6 +107,8 @@ dotnet publish test/Hello.csproj -r linux-musl-arm64
 dotnet publish test/Hello.csproj -r linux-musl-arm  # armv7; publishes as net9.0
 dotnet publish test/Hello.csproj -r osx-x64     # Experimental
 dotnet publish test/Hello.csproj -r osx-arm64   # Experimental
+dotnet publish test/Hello.csproj -r win-x64     # From Linux/macOS hosts (zig/MinGW link)
+dotnet publish test/Hello.csproj -r win-arm64   # From Linux/macOS hosts (zig/MinGW link)
 ```
 
 #### Debugging Cross-Compilation Issues
@@ -149,6 +152,13 @@ For development and iteration on the clang shim, using external Zig is preferred
 - Check that target platform flags are correctly detected
 - Verify system libraries are available
 - Review filtered arguments in script output
+
+#### Windows cross-compilation notes
+
+- Only reachable from non-Windows hosts (on Windows the SDK's native MSVC link applies and the package is inert)
+- The link shim writes its glue (`aotanywhere-msvc-glue.c`) and stub archives (`aotanywhere-msvc-stub-libs/`) next to the `link.rsp` in the native intermediate directory; `ZIG_SHIM_DEBUG=1` prints the original and translated argument lists
+- New undefined MSVC CRT symbols on future .NET versions belong in `glue_source` in `src/link_shim.zig`; keep definitions exactly ABI-faithful (the arm64 `__security_push_cookie`/`__security_pop_cookie` follow MSVC's `crt/arm64/secpushpop.asm` contract)
+- `/MERGE`, `/guard:cf` and `/CETCOMPAT` are intentionally dropped: zig cc cannot express them and they are not needed for correctness
 
 #### macOS cross-compilation notes
 - Links against the bundled `.tbd` stubs in `src/apple-sysroot`; unresolved Apple symbols on newer .NET versions mean the stubs need regenerating

--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -108,6 +108,24 @@ for target in "${TARGET_ARRAY[@]}"; do
       echo "❌ Cross-compilation build failed for $target"
       build_result="failed"
     fi
+  elif [[ "$target" == win-* ]]; then
+    echo "Publishing Windows target..."
+    # On Windows hosts the SDK links win-* natively with MSVC and the
+    # package stays inert - which is itself worth validating. On Linux and
+    # macOS hosts the shim's link personality drives zig's MinGW link.
+    if dotnet publish test/Hello.csproj \
+      -r "$target" \
+      -c Release \
+      -p:InvariantGlobalization=true \
+      -p:BaseIntermediateOutputPath="$obj_dir" \
+      --output "artifacts/$host_name/$target"; then
+
+      echo "✅ Windows publish succeeded for $target"
+      build_result="success"
+    else
+      echo "❌ Windows publish failed for $target"
+      build_result="failed"
+    fi
   else
     echo "❌ Unknown target platform: $target"
     build_result="failed"
@@ -116,6 +134,7 @@ for target in "${TARGET_ARRAY[@]}"; do
   # Verify the binary was created (if build was successful)
   if [[ "$build_result" == "success" ]]; then
     binary_name="Hello"
+    [[ "$target" == win-* ]] && binary_name="Hello.exe"
 
     if [ -f "artifacts/$host_name/$target/$binary_name" ]; then
       echo "✅ Binary confirmed: $binary_name for $target"
@@ -139,6 +158,18 @@ for target in "${TARGET_ARRAY[@]}"; do
           echo "✅ Symbol sidecar check: Hello.dbg present"
         else
           echo "❌ Symbol sidecar check: Hello.dbg missing (StripSymbols pipeline did not run)"
+          build_success=false
+        fi
+      fi
+
+      # Assert the PDB made it to the publish output for Windows targets:
+      # copied by the SDK on Windows hosts and by the package's
+      # AotAnywhereCopyWindowsPdb target on cross hosts.
+      if [[ "$target" == win-* ]]; then
+        if [ -f "artifacts/$host_name/$target/Hello.pdb" ]; then
+          echo "✅ Symbol sidecar check: Hello.pdb present"
+        else
+          echo "❌ Symbol sidecar check: Hello.pdb missing"
           build_success=false
         fi
       fi

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: src/obj/shim
-          key: prebuilt-shims-${{ hashFiles('src/clang_shim.zig', 'src/objcopy_shim.zig', 'src/AotAnywhere.nuproj') }}
+          key: prebuilt-shims-${{ hashFiles('src/clang_shim.zig', 'src/objcopy_shim.zig', 'src/link_shim.zig', 'src/AotAnywhere.nuproj') }}
       - name: Setup .NET
         if: steps.shim-cache.outputs.cache-hit != 'true'
         uses: actions/setup-dotnet@v5
@@ -120,8 +120,8 @@ jobs:
           name: test-signing-cert
           path: test-cert/
 
-  # Build matrix: every host builds all eight targets; the target list lives
-  # in the parallel build steps below (grouped glibc/musl/macOS).
+  # Build matrix: every host builds all ten targets; the target list lives
+  # in the parallel build steps below (grouped glibc/musl/macOS/Windows).
   build:
     needs: [pack, test-cert]
     strategy:
@@ -222,8 +222,8 @@ jobs:
         shell: bash
         run: dotnet restore test/Hello.csproj
 
-      # The eight publishes are independent, so run them as three concurrent
-      # streams (Actions parallel steps). Three streams - not eight - because
+      # The ten publishes are independent, so run them as four concurrent
+      # streams (Actions parallel steps). Four streams - not ten - because
       # the hosted runners have 3-4 cores and ILC is memory-hungry; grouping
       # keeps them saturated without thrashing. build-targets.sh gives each
       # target its own intermediate dir so the concurrent publishes of the
@@ -246,6 +246,11 @@ jobs:
             env:
               ZIG_SHIM_DEBUG: "1"
             run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "osx-x64,osx-arm64"
+          - name: Build Windows targets
+            shell: bash
+            env:
+              ZIG_SHIM_DEBUG: "1"
+            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "win-x64,win-arm64"
 
 
       - name: Upload build artifacts
@@ -293,6 +298,19 @@ jobs:
           - runner: macos-latest
             runner-name: macos-arm64
             test-targets: "osx-arm64"
+            host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
+          # Test Windows x64 binaries on Windows x64. The windows-host builds
+          # are MSVC-linked (package inert there); the others are zig-linked
+          # by the shim's link personality, so this is where the MinGW-glued
+          # binaries prove they actually run.
+          - runner: windows-latest
+            runner-name: windows-x64
+            test-targets: "win-x64"
+            host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
+          # Test Windows ARM64 binaries on the hosted arm64 Windows runner.
+          - runner: windows-11-arm
+            runner-name: windows-arm64
+            test-targets: "win-arm64"
             host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
     
     runs-on: ${{ matrix.runner }}
@@ -377,7 +395,9 @@ jobs:
             echo ""
             
             for target in "${TARGET_ARRAY[@]}"; do
-              binary_path="binaries-$host/$target/Hello"
+              binary_name="Hello"
+              [[ "$target" == win-* ]] && binary_name="Hello.exe"
+              binary_path="binaries-$host/$target/$binary_name"
               skip_file="binaries-$host/$target/SKIPPED.txt"
               
               total_count=$((total_count + 1))
@@ -448,7 +468,8 @@ jobs:
               # Try to run the binary with timeout
               echo -n "  Execution test: "
               if run_binary "$binary_path" > /tmp/output.txt 2>&1; then
-                output=$(cat /tmp/output.txt)
+                # tr strips the \r that Windows console output leaves in the line.
+                output=$(tr -d '\r' < /tmp/output.txt)
                 if [[ "$output" == "Hello World" ]]; then
                   echo "✅ SUCCESS - Output: '$output'"
                   success_count=$((success_count + 1))
@@ -532,7 +553,7 @@ jobs:
               # Count successful builds
               success_count=0
               for target_dir in binaries-$host/*/; do
-                if [ -f "${target_dir}Hello" ]; then
+                if [ -f "${target_dir}Hello" ] || [ -f "${target_dir}Hello.exe" ]; then
                   success_count=$((success_count + 1))
                 fi
               done
@@ -557,7 +578,9 @@ jobs:
           echo "| Target Platform | Windows Host | Linux Host | macOS x64 Host | macOS ARM64 Host | Linux ARM64 Host | Runtime Validation |" >> platform-report.md
           echo "|-----------------|--------------|------------|----------------|------------------|------------------|-------------------|" >> platform-report.md
 
-          for target in linux-x64 linux-arm64 linux-arm linux-musl-x64 linux-musl-arm64 linux-musl-arm osx-x64 osx-arm64; do
+          for target in linux-x64 linux-arm64 linux-arm linux-musl-x64 linux-musl-arm64 linux-musl-arm osx-x64 osx-arm64 win-x64 win-arm64; do
+            bin="Hello"
+            [[ "$target" == win-* ]] && bin="Hello.exe"
             win_status="❌"
             linux_status="❌"
             mac_x64_status="❌"
@@ -566,16 +589,16 @@ jobs:
             runtime_status="❌ No binaries"
 
             # Check build status
-            [ -f "binaries-windows/$target/Hello" ] && win_status="✅"
-            [ -f "binaries-linux/$target/Hello" ] && linux_status="✅"
-            [ -f "binaries-macos-x64/$target/Hello" ] && mac_x64_status="✅"
-            [ -f "binaries-macos-arm64/$target/Hello" ] && mac_arm64_status="✅"
-            [ -f "binaries-linux-arm64/$target/Hello" ] && linux_arm64_status="✅"
+            [ -f "binaries-windows/$target/$bin" ] && win_status="✅"
+            [ -f "binaries-linux/$target/$bin" ] && linux_status="✅"
+            [ -f "binaries-macos-x64/$target/$bin" ] && mac_x64_status="✅"
+            [ -f "binaries-macos-arm64/$target/$bin" ] && mac_arm64_status="✅"
+            [ -f "binaries-linux-arm64/$target/$bin" ] && linux_arm64_status="✅"
 
             # Runtime validation: every target now has a validation runner
-            # (x64 and ARM64 Linux, plus both macOS architectures).
+            # (x64 and ARM64 Linux and Windows, plus both macOS architectures).
             for host in windows linux macos-x64 macos-arm64 linux-arm64; do
-              if [ -f "binaries-$host/$target/Hello" ]; then
+              if [ -f "binaries-$host/$target/$bin" ]; then
                 runtime_status="✅ Testable"
                 break
               fi
@@ -597,16 +620,18 @@ jobs:
           for host in windows linux macos-x64 macos-arm64 linux-arm64; do
             if [ -d "binaries-$host" ]; then
               for target_dir in binaries-$host/*/; do
-                if [ -f "${target_dir}Hello" ]; then
+                bin="${target_dir}Hello"
+                [ -f "${target_dir}Hello.exe" ] && bin="${target_dir}Hello.exe"
+                if [ -f "$bin" ]; then
                   target=$(basename "$target_dir")
-                  size_info=$(ls -lh "${target_dir}Hello" | awk '{print $5}')
-                  
+                  size_info=$(ls -lh "$bin" | awk '{print $5}')
+
                   # Get architecture info if file command is available
                   arch_info="Unknown"
                   if command -v file >/dev/null 2>&1; then
-                    arch_info=$(file "${target_dir}Hello" | cut -d',' -f2 | xargs)
+                    arch_info=$(file "$bin" | cut -d',' -f2 | xargs)
                   fi
-                  
+
                   echo "| $host → $target | $size_info | $arch_info |" >> platform-report.md
                 fi
               done
@@ -622,7 +647,7 @@ jobs:
           echo "## Additional Notes" >> platform-report.md
           echo "- This matrix shows cross-compilation capabilities from different host platforms" >> platform-report.md
           echo "- Builds run from x64 and ARM64 Windows, Linux, and macOS hosts" >> platform-report.md
-          echo "- Runtime validation covers Linux (x64 and ARM64) and macOS (x64 and ARM64) targets on matching hosted runners; ARMv7 targets run under QEMU in arm/v7 containers" >> platform-report.md
+          echo "- Runtime validation covers Linux, macOS and Windows (x64 and ARM64) targets on matching hosted runners; ARMv7 targets run under QEMU in arm/v7 containers" >> platform-report.md
           echo "- All builds use .NET 8.0 with Native AOT and Zig for cross-compilation, except the ARMv7 targets which use .NET 9.0 (their ILCompiler packs only ship for .NET 9+)" >> platform-report.md
           echo "" >> platform-report.md
           echo "Generated on: $(date -u)" >> platform-report.md

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ $ dotnet publish -r linux-x64
 Microsoft.NETCore.Native.Publish.targets(59,5): error : Cross-OS native compilation is not supported.
 ```
 
-This NuGet package allows using [Zig](https://ziglang.org/) as the linker/sysroot to allow crosscompiling to linux-x64/linux-arm64/linux-arm/linux-musl-x64/linux-musl-arm64/linux-musl-arm as well as osx-x64/osx-arm64 from Windows, macOS, and Linux machines.
+This NuGet package allows using [Zig](https://ziglang.org/) as the linker/sysroot to allow crosscompiling to linux-x64/linux-arm64/linux-arm/linux-musl-x64/linux-musl-arm64/linux-musl-arm as well as osx-x64/osx-arm64 and win-x64/win-arm64 from Windows, macOS, and Linux machines.
 
 ## Supported Host Platforms
 
@@ -21,6 +21,7 @@ This NuGet package allows using [Zig](https://ziglang.org/) as the linker/sysroo
 
 - **Linux** (x64, arm64, arm/ARMv7, glibc, musl) - Full support from all host platforms (the arm/ARMv7 targets require a `net9.0`+ target framework; see [Usage](#usage))
 - **macOS** (x64, arm64) - Cross-compilation using Apple linker stubs bundled with the package (see below)
+- **Windows** (x64, arm64) - Cross-compilation from Linux and macOS hosts using zig's bundled MinGW-w64 import libraries (see below; on a Windows host the SDK links win-* natively with MSVC and this package stays out of the way)
 
 ### macOS Cross-Compilation
 
@@ -32,6 +33,17 @@ Things to know:
 - Symbols are not stripped for macOS targets (`StripSymbols` defaults to `false` there): Apple's `strip`/`dsymutil` are unavailable on other hosts and reject zig-linked binaries anyway.
 - zig gives osx-arm64 binaries an ad-hoc code signature (Apple Silicon refuses to run entirely unsigned code); osx-x64 binaries are left unsigned. Either way that only covers running locally — for distribution you should sign (and if needed notarize) the result, which works from any host, no Mac required; see [Signing and notarizing macOS binaries](#signing-and-notarizing-macos-binaries) below.
 - To link against a real Apple SDK instead of the bundled stubs, set the `AotAnywhereAppleSysroot` MSBuild property (or the `AOTANYWHERE_APPLE_SYSROOT` environment variable) to the SDK root.
+
+### Windows Cross-Compilation
+
+On a Linux or macOS host, `dotnet publish -r win-x64` (or `win-arm64`) normally stops at the `link.exe` step, since there is no MSVC. The package bridges that: the shim also materializes as `link`, translates the MSVC-style response file the ILC targets write, and drives `zig cc -target <arch>-windows-gnu`, which links with lld against the MinGW-w64 (UCRT) import libraries zig bundles. The MSVC-built NativeAOT runtime libraries link against the MinGW C runtime through a small glue object the shim injects (MSVC `/GS` stack-cookie helpers, MSVC-mangled `operator new`/`delete`, the arm64 `_Interlocked*` out-of-line helpers, and a few marker symbols).
+
+Things to know:
+
+- The output imports the Universal CRT (`api-ms-win-crt-*`), exactly like an MSVC-linked NativeAOT binary, so it runs on any stock Windows 10+ system with no extra runtime.
+- A `.pdb` is produced next to the binary and copied to the publish directory, as on Windows.
+- Some MSVC hardening/link features are not carried over: the `/GS` stack cookie keeps a fixed (non-randomized) value, and Control Flow Guard and CET shadow-stack markers (`/CETCOMPAT`) are not emitted. `/MERGE` is also skipped, making the output slightly larger than an MSVC link. For maximum-hardening release builds, link on Windows with MSVC.
+- On a Windows host the package does nothing for `win-*` RIDs; the SDK's native MSVC link (including cross-arch win-x64 ↔ win-arm64 with the right VS components) applies.
 
 ### Signing and notarizing macOS binaries
 
@@ -110,6 +122,10 @@ By default it relies on Zig provided by the unofficial [Vezel.Zig.Toolsets](http
     * `dotnet publish -r linux-musl-x64`
     * `dotnet publish -r linux-musl-arm64`
     * `dotnet publish -r linux-musl-arm` (requires .NET 9+)
+    * `dotnet publish -r osx-x64`
+    * `dotnet publish -r osx-arm64`
+    * `dotnet publish -r win-x64`
+    * `dotnet publish -r win-arm64`
 
    The armv7 targets (`linux-arm`, `linux-musl-arm`) need a `net9.0` or later target framework: .NET only ships ILCompiler runtime packs for them from .NET 9 onwards.
 
@@ -151,7 +167,7 @@ Note: Using invariant globalization disables culture-specific formatting, sortin
 
 ### The clang shim
 
-Cross-compilation works by putting a small `clang` shim on `PATH` that rewrites the linker invocation and forwards it to `zig cc`. The package ships this shim **prebuilt** for the common host RIDs (Windows x86/x64, macOS x64/arm64, Linux x64/arm64) under `build/shim/<host-rid>`, so a normal build just copies it and does no compilation. On any other host the shim is compiled on demand from the bundled `clang_shim.zig` with the Zig toolchain. Pass `/p:UsePrebuiltClangShim=false` to force the compile-on-demand path.
+Cross-compilation works by putting a small `clang` shim on `PATH` that rewrites the linker invocation and forwards it to `zig cc`. It is a multi-call binary: materialized as `llvm-objcopy` it performs the Linux symbol strip, and materialized as `link` it stands in for MSVC's linker when targeting Windows from a non-Windows host. The package ships this shim **prebuilt** for the common host RIDs (Windows x86/x64, macOS x64/arm64, Linux x64/arm64) under `build/shim/<host-rid>`, so a normal build just copies it and does no compilation. On any other host the shim is compiled on demand from the bundled `clang_shim.zig` with the Zig toolchain. Pass `/p:UsePrebuiltClangShim=false` to force the compile-on-demand path.
 
 The prebuilt shims are cross-compiled from a single machine at pack time (see `BuildClangShims` in `AotAnywhere.nuproj`); Zig makes producing all host binaries from one host trivial.
 
@@ -159,11 +175,8 @@ The prebuilt shims are cross-compiled from a single machine at pack time (see `B
 
 If you don't want to use Zig from the Vezel.Zig.Toolsets NuGet package, you can specify `/p:UseExternalZig=true`. This will use whatever Zig is on your PATH. [Download](https://ziglang.org/download/) an archive with Zig for your host machine, extract it and place it on your PATH.
 
-
-Even though Zig allows crosscompiling for Windows as well, it's not possible to crosscompile PublishAot like this due to ABI differences (MSVC vs. MingW ABI).
-
 ## Cross-Platform Validation
 
-This repository includes a comprehensive GitHub Actions workflow that validates cross-compilation support across different host and target platforms. The workflow tests building from Windows and macOS hosts to all supported Linux targets (x64, ARM64, ARMv7, glibc, musl) and validates that the produced binaries run correctly (natively on hosted runners, or under QEMU in arm/v7 containers for the ARMv7 targets).
+This repository includes a comprehensive GitHub Actions workflow that validates cross-compilation support across different host and target platforms. The workflow tests building from Windows, Linux and macOS hosts to all supported Linux, macOS and Windows targets and validates that the produced binaries run correctly (natively on hosted runners, or under QEMU in arm/v7 containers for the ARMv7 targets).
 
 See [docs/cross-platform-validation.md](docs/cross-platform-validation.md) for detailed information about the validation process and platform support matrix.

--- a/docs/cross-platform-validation.md
+++ b/docs/cross-platform-validation.md
@@ -18,6 +18,8 @@ This repository includes a comprehensive GitHub Actions workflow (`cross-platfor
 - `linux-musl-arm` (armv7, published as `net9.0`)
 - `osx-x64`
 - `osx-arm64`
+- `win-x64`
+- `win-arm64`
 
 ## Workflow Structure
 
@@ -30,7 +32,7 @@ strategy:
     include:
       - host: windows-latest
         host-name: windows
-        targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64"
+        targets: "linux-x64,linux-arm64,linux-arm,linux-musl-x64,linux-musl-arm64,linux-musl-arm,osx-x64,osx-arm64,win-x64,win-arm64"
       # ... same target list from ubuntu-latest, ubuntu-24.04-arm,
       # macos-15-intel and macos-latest hosts
 ```
@@ -51,6 +53,7 @@ A dedicated job generates a throwaway self-signed Developer ID-style certificate
 - Tests x64 binaries on Ubuntu x64 and ARM64 binaries on Ubuntu ARM64 runners
 - Tests ARMv7 binaries under QEMU on the x64 runner, inside `linux/arm/v7` containers (Debian for the glibc target, Alpine for musl) — there is no hosted armv7 runner, and the hosted arm64 runners dropped 32-bit execution
 - Tests macOS binaries on appropriate macOS runners (x64 on macos-15-intel, ARM64 on macos-latest)
+- Tests Windows binaries on Windows runners (win-x64 on windows-latest, win-arm64 on windows-11-arm); binaries from the Windows host are MSVC-linked, the rest are zig/MinGW-linked by the shim's link personality
 - On macOS runners, verifies code signatures with `codesign --verify --strict` (and checks the `osx-x64` binaries carry the CI test certificate) before running
 - Verifies "Hello World" output
 - Reports success/failure rates
@@ -72,7 +75,7 @@ The workflow can be triggered by:
 ## Expected Results
 
 The workflow validates that AotAnywhere successfully enables:
-- Cross-compilation from Windows/macOS to Linux and macOS
+- Cross-compilation from Windows/Linux/macOS hosts to Linux, macOS and Windows targets
 - Support for both glibc and musl targets on Linux
 - Support for x64, ARM64 and ARMv7 architectures
 - Functional binaries that run correctly on target platforms

--- a/src/AotAnywhere.nuproj
+++ b/src/AotAnywhere.nuproj
@@ -40,6 +40,10 @@
       <Pack>true</Pack>
       <PackagePath>build</PackagePath>
     </None>
+    <None Include="link_shim.zig">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
     <None Include="apple-sysroot/**">
       <Pack>true</Pack>
       <PackagePath>build/apple-sysroot</PackagePath>
@@ -93,7 +97,7 @@
 
   <Target Name="BuildClangShims"
           DependsOnTargets="_ResolveZigForShims"
-          Inputs="clang_shim.zig;objcopy_shim.zig;@(ShimTarget)"
+          Inputs="clang_shim.zig;objcopy_shim.zig;link_shim.zig;@(ShimTarget)"
           Outputs="@(ShimTarget->'$(ShimIntermediateDir)%(Identity)/%(Exe)')">
 
     <MakeDir Directories="$(ShimIntermediateDir)%(ShimTarget.Identity)" />
@@ -117,6 +121,7 @@
   <ItemGroup>
     <ShimSource Include="clang_shim.zig" />
     <ShimSource Include="objcopy_shim.zig" />
+    <ShimSource Include="link_shim.zig" />
   </ItemGroup>
 
   <!-- Register the shims for packing in a separate, always-run target: doing it

--- a/src/Crosscompile.targets
+++ b/src/Crosscompile.targets
@@ -31,6 +31,20 @@
          works with no LLVM install. -->
     <ObjCopyShimBinary Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(ClangShimDir)llvm-objcopy.exe</ObjCopyShimBinary>
     <ObjCopyShimBinary Condition="'$(ObjCopyShimBinary)' == ''">$(ClangShimDir)llvm-objcopy</ObjCopyShimBinary>
+
+    <!-- Materialized a third time as link, the shim stands in for MSVC's
+         link.exe when targeting Windows from a Linux/macOS host: it
+         translates the MSVC-style response file the ILC targets write into
+         a `zig cc -target <arch>-windows-gnu` invocation. -->
+    <LinkShimBinary Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(ClangShimDir)link.exe</LinkShimBinary>
+    <LinkShimBinary Condition="'$(LinkShimBinary)' == ''">$(ClangShimDir)link</LinkShimBinary>
+
+    <!-- Cross-compiling to Windows: skip the ILC targets' vcvarsall probe (a
+         Windows batch file) so CppLinker stays at its plain-'link' default,
+         which OverwriteTargetTriple then points at the link shim. -->
+    <_AotAnywhereWindowsCross>false</_AotAnywhereWindowsCross>
+    <_AotAnywhereWindowsCross Condition="$(RuntimeIdentifier.StartsWith('win')) and !$([MSBuild]::IsOSPlatform('Windows'))">true</_AotAnywhereWindowsCross>
+    <IlcUseEnvironmentalTools Condition="'$(_AotAnywhereWindowsCross)' == 'true'">true</IlcUseEnvironmentalTools>
   </PropertyGroup>
 
   <ItemGroup>
@@ -107,11 +121,11 @@
           Condition="'$(UsePrebuiltClangShim)' == 'true'"
           BeforeTargets="SetupOSSpecificProps"
           Inputs="$(PrebuiltClangShim)"
-          Outputs="$(ClangShimBinary);$(ObjCopyShimBinary)">
+          Outputs="$(ClangShimBinary);$(ObjCopyShimBinary);$(LinkShimBinary)">
 
     <MakeDir Directories="$(ClangShimDir)" />
-    <Copy SourceFiles="$(PrebuiltClangShim);$(PrebuiltClangShim)" DestinationFiles="$(ClangShimBinary);$(ObjCopyShimBinary)" OverwriteReadOnlyFiles="true" />
-    <Exec Condition="!$([MSBuild]::IsOSPlatform('Windows'))" Command="chmod +x &quot;$(ClangShimBinary)&quot; &quot;$(ObjCopyShimBinary)&quot;" />
+    <Copy SourceFiles="$(PrebuiltClangShim);$(PrebuiltClangShim);$(PrebuiltClangShim)" DestinationFiles="$(ClangShimBinary);$(ObjCopyShimBinary);$(LinkShimBinary)" OverwriteReadOnlyFiles="true" />
+    <Exec Condition="!$([MSBuild]::IsOSPlatform('Windows'))" Command="chmod +x &quot;$(ClangShimBinary)&quot; &quot;$(ObjCopyShimBinary)&quot; &quot;$(LinkShimBinary)&quot;" />
 
   </Target>
 
@@ -120,13 +134,13 @@
           Condition="'$(UsePrebuiltClangShim)' != 'true'"
           DependsOnTargets="SetPathToZig"
           BeforeTargets="SetupOSSpecificProps"
-          Inputs="$(ClangShimSource);$(MSBuildThisFileDirectory)objcopy_shim.zig"
-          Outputs="$(ClangShimBinary);$(ObjCopyShimBinary)">
+          Inputs="$(ClangShimSource);$(MSBuildThisFileDirectory)objcopy_shim.zig;$(MSBuildThisFileDirectory)link_shim.zig"
+          Outputs="$(ClangShimBinary);$(ObjCopyShimBinary);$(LinkShimBinary)">
 
     <MakeDir Directories="$(ClangShimDir)" />
     <Exec Command="zig build-exe -O ReleaseSafe -femit-bin=&quot;$(ClangShimBinary)&quot; &quot;$(ClangShimSource)&quot;" />
-    <Copy SourceFiles="$(ClangShimBinary)" DestinationFiles="$(ObjCopyShimBinary)" OverwriteReadOnlyFiles="true" />
-    <Exec Condition="!$([MSBuild]::IsOSPlatform('Windows'))" Command="chmod +x &quot;$(ObjCopyShimBinary)&quot;" />
+    <Copy SourceFiles="$(ClangShimBinary);$(ClangShimBinary)" DestinationFiles="$(ObjCopyShimBinary);$(LinkShimBinary)" OverwriteReadOnlyFiles="true" />
+    <Exec Condition="!$([MSBuild]::IsOSPlatform('Windows'))" Command="chmod +x &quot;$(ObjCopyShimBinary)&quot; &quot;$(LinkShimBinary)&quot;" />
 
   </Target>
 
@@ -185,12 +199,20 @@
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('linux'))">$(CrossCompileArch)-linux-gnu$(CrossCompileAbiSuffix)</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-linux-musl$(CrossCompileAbiSuffix)</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('osx'))">$(CrossCompileArch)-macos</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.StartsWith('win'))">$(CrossCompileArch)-windows-gnu</TargetTriple>
 
       <!-- Apple's strip/dsymutil reject zig-linked binaries (and don't exist
            on Linux/Windows hosts), so default to keeping symbols for macOS
            targets. An explicit /p:StripSymbols=true still wins. -->
       <StripSymbols Condition="$(CrossCompileRid.StartsWith('osx'))">false</StripSymbols>
+
+      <!-- Point the ILC targets' MSVC link step at the shim's link
+           personality, which rewrites it to a zig invocation. -->
+      <CppLinker Condition="'$(_AotAnywhereWindowsCross)' == 'true'">$(LinkShimBinary)</CppLinker>
     </PropertyGroup>
+
+    <Error Condition="'$(_AotAnywhereWindowsCross)' == 'true' and '$(CrossCompileArch)' == ''"
+           Text="AotAnywhere: cross-compiling to '$(RuntimeIdentifier)' is not supported; of the Windows targets only win-x64 and win-arm64 are." />
 
     <ItemGroup>
       <LinkerArg Include="--target=$(TargetTriple)" />
@@ -198,6 +220,19 @@
 
   </Target>
   <!-- END: Works around ILCompiler targets not detecting this as a cross compilation -->
+
+  <!-- For Windows targets lld writes $(TargetName).pdb next to the binary
+       (the name the PE's CodeView record references), but the SDK's
+       _CopyAotSymbols only knows MSVC's host-Windows layout and misses it.
+       Copy it to the publish directory ourselves, after _CopyAotSymbols has
+       finished deleting the managed .pdb it replaces. -->
+  <Target Name="AotAnywhereCopyWindowsPdb"
+          AfterTargets="_CopyAotSymbols"
+          Condition="'$(_AotAnywhereWindowsCross)' == 'true' and '$(CopyOutputSymbolsToPublishDirectory)' != 'false' and Exists('$(NativeOutputPath)$(TargetName).pdb')">
+
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).pdb" DestinationFolder="$(PublishDir)" />
+
+  </Target>
 
   <!-- zig leaves an ad-hoc code signature on macOS binaries, which runs
        locally but is not suitable for distribution. This re-signs the linked

--- a/src/StuDev.AotAnywhere.targets
+++ b/src/StuDev.AotAnywhere.targets
@@ -1,6 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Windows, Linux, and macOS hosts targeting Linux and macOS are supported -->
-  <Import Project="Crosscompile.targets" Condition="$(RuntimeIdentifier.Contains('linux')) or $(RuntimeIdentifier.Contains('osx'))" />
+  <!-- Windows, Linux, and macOS hosts targeting Linux and macOS are supported,
+       plus Linux and macOS hosts targeting Windows (on a Windows host the SDK
+       links win-* natively with MSVC, so the package stays out of the way). -->
+  <Import Project="Crosscompile.targets" Condition="$(RuntimeIdentifier.Contains('linux')) or $(RuntimeIdentifier.Contains('osx')) or ($(RuntimeIdentifier.StartsWith('win')) and !$([MSBuild]::IsOSPlatform('Windows')))" />
 
 </Project>

--- a/src/clang_shim.zig
+++ b/src/clang_shim.zig
@@ -2,10 +2,13 @@
 //! adjusting arguments for native compilation and cross-compilation.
 //!
 //! This is a multi-call binary: Crosscompile.targets materializes the same
-//! executable as both `clang` and `llvm-objcopy`, and it dispatches on the
-//! name it was invoked as. The objcopy personality (objcopy_shim.zig) covers
-//! the symbol stripping the ILC targets perform for Linux targets, so
-//! StripSymbols works with no LLVM install.
+//! executable as `clang`, `llvm-objcopy` and `link`, and it dispatches on
+//! the name it was invoked as. The objcopy personality (objcopy_shim.zig)
+//! covers the symbol stripping the ILC targets perform for Linux targets,
+//! so StripSymbols works with no LLVM install. The link personality
+//! (link_shim.zig) stands in for MSVC's link.exe when targeting Windows
+//! from a non-Windows host, translating the MSVC-style link step to
+//! `zig cc -target <arch>-windows-gnu`.
 //!
 //! Crosscompile.targets compiles this on demand with the zig toolchain the
 //! package already provides, so no prebuilt binaries need to ship and the
@@ -22,6 +25,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const objcopy_shim = @import("objcopy_shim.zig");
+const link_shim = @import("link_shim.zig");
 
 const host_is_macos = builtin.os.tag == .macos;
 
@@ -48,6 +52,9 @@ pub fn main(init: std.process.Init) !void {
 
     if (argv.len > 0 and isObjcopyInvocation(argv[0]))
         objcopy_shim.run(arena, io, args);
+
+    if (argv.len > 0 and link_shim.isLinkInvocation(argv[0]))
+        link_shim.run(arena, io, args, debug);
 
     var out: Args = .empty;
     try out.appendSlice(arena, &.{ "zig", "cc" });
@@ -370,6 +377,7 @@ const testing = std.testing;
 
 test {
     _ = objcopy_shim; // include the objcopy personality's tests
+    _ = link_shim; // include the link personality's tests
 }
 
 test "objcopy invocations are detected by executable name" {

--- a/src/link_shim.zig
+++ b/src/link_shim.zig
@@ -1,0 +1,774 @@
+//! link_shim.zig - link.exe personality of the AotAnywhere shim.
+//!
+//! When targeting Windows (win-x64, win-arm64) the ILC targets write an
+//! MSVC-style response file and invoke `link @obj/.../link.rsp`. On
+//! non-Windows hosts there is no MSVC, so Crosscompile.targets points
+//! CppLinker at this personality instead. It expands the response file,
+//! translates the MSVC linker options to their GNU-driver equivalents and
+//! forwards the invocation to `zig cc -target <arch>-windows-gnu`, which
+//! links with lld against the MinGW-w64 (UCRT) import libraries bundled
+//! with zig.
+//!
+//! Two gaps between the MSVC-built NativeAOT runtime libraries and the
+//! MinGW CRT are bridged on the fly:
+//!
+//!   - The objects carry /DEFAULTLIB directives for MSVC-only libraries
+//!     (LIBCMT, OLDNAMES, libcpmt, uuid). Empty stub archives are written
+//!     next to the response file so lld finds them; the MinGW CRT provides
+//!     the actual C runtime.
+//!   - A small glue source (compiled as part of the link) supplies the MSVC
+//!     CRT symbols the MinGW CRT lacks: /GS stack-cookie support, the MSVC
+//!     on-demand TLS init scheme, MSVC-mangled operator new/delete, and the
+//!     arm64 out-of-line _Interlocked* helpers. See `glue_source` below.
+//!
+//! The target triple arrives as a `--target=<triple>` line that
+//! Crosscompile.targets injects into the response file via LinkerArg.
+//!
+//! Run the unit tests with: zig test src/clang_shim.zig (this file is
+//! covered through its import there) or directly: zig test src/link_shim.zig
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+const Args = std.ArrayList([]const u8);
+
+/// True when the multi-call binary was invoked under a link name (link,
+/// link.exe, any path or casing). Matching is exact on the basename so
+/// names like clang/llvm-objcopy can never trip it.
+pub fn isLinkInvocation(argv0: []const u8) bool {
+    var base = if (std.mem.lastIndexOfAny(u8, argv0, "/\\")) |sep| argv0[sep + 1 ..] else argv0;
+    if (std.ascii.endsWithIgnoreCase(base, ".exe")) base = base[0 .. base.len - 4];
+    return std.ascii.eqlIgnoreCase(base, "link");
+}
+
+/// Entry point when the shim is invoked as link. Never returns.
+pub fn run(arena: Allocator, io: std.Io, args: []const []const u8, debug: bool) noreturn {
+    const reader = IoFileReader{ .io = io };
+    const tokens = expandResponseFiles(arena, reader, args, 0) catch |err|
+        fatal(io, "cannot expand response files: {s}", .{@errorName(err)});
+
+    const translation = translate(arena, tokens.items) catch |err|
+        fatal(io, "cannot translate linker arguments: {s}", .{@errorName(err)});
+
+    for (translation.warnings.items) |warning| say(io, "{s}", .{warning});
+    if (!translation.saw_target)
+        say(io, "Warning: no --target=<triple> argument was injected; linking for the host by mistake is likely.", .{});
+
+    // The MSVC-glue support files live next to the response file (the native
+    // intermediate directory), falling back to the output directory.
+    const support_dir = tokens.rsp_dir orelse
+        (if (translation.out_path) |out| std.fs.path.dirname(out) else null) orelse ".";
+    const glue_path = writeSupportFiles(arena, io, support_dir) catch |err|
+        fatal(io, "cannot write support files in '{s}': {s}", .{ support_dir, @errorName(err) });
+
+    var argv: Args = .empty;
+    argv.appendSlice(arena, &.{ "zig", "cc" }) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+    argv.appendSlice(arena, translation.args.items) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+    argv.append(arena, glue_path) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+    const stub_arg = std.fmt.allocPrint(arena, "-L{s}", .{
+        std.fs.path.join(arena, &.{ support_dir, stub_dir_name }) catch |err|
+            fatal(io, "out of memory: {s}", .{@errorName(err)}),
+    }) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+    argv.append(arena, stub_arg) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+
+    if (debug) {
+        say(io, "[DEBUG] Original args:", .{});
+        for (args) |arg| say(io, "  '{s}'", .{arg});
+        say(io, "[DEBUG] Final command:", .{});
+        for (argv.items) |arg| say(io, "  '{s}'", .{arg});
+    }
+
+    execZigCc(io, argv.items);
+}
+
+// --- Response files ----------------------------------------------------------
+
+/// Reads files through std.Io; tests substitute an in-memory reader.
+const IoFileReader = struct {
+    io: std.Io,
+
+    fn read(self: IoFileReader, arena: Allocator, path: []const u8) ![]u8 {
+        return std.Io.Dir.cwd().readFileAlloc(self.io, path, arena, .unlimited);
+    }
+};
+
+const ExpandedTokens = struct {
+    items: []const []const u8,
+    /// Directory of the first response file, when one was used.
+    rsp_dir: ?[]const u8,
+};
+
+/// Expands @file arguments into their tokenized contents. MSBuild writes the
+/// response file as UTF-8 with a BOM, one or more space-separated (possibly
+/// quoted) arguments per line.
+fn expandResponseFiles(arena: Allocator, reader: anytype, args: []const []const u8, depth: usize) !ExpandedTokens {
+    if (depth > 8) return error.ResponseFileRecursionTooDeep;
+
+    var out: Args = .empty;
+    var rsp_dir: ?[]const u8 = null;
+    for (args) |arg| {
+        if (arg.len > 1 and arg[0] == '@') {
+            const path = arg[1..];
+            var contents: []const u8 = try reader.read(arena, path);
+            if (std.mem.startsWith(u8, contents, "\xEF\xBB\xBF")) {
+                contents = contents[3..];
+            } else if (std.mem.startsWith(u8, contents, "\xFF\xFE") or std.mem.startsWith(u8, contents, "\xFE\xFF")) {
+                return error.Utf16ResponseFileUnsupported;
+            }
+
+            var line_tokens: Args = .empty;
+            var lines = std.mem.splitScalar(u8, contents, '\n');
+            while (lines.next()) |line| {
+                try tokenizeLine(arena, std.mem.trimEnd(u8, line, "\r"), &line_tokens);
+            }
+            const inner = try expandResponseFiles(arena, reader, line_tokens.items, depth + 1);
+            try out.appendSlice(arena, inner.items);
+            if (rsp_dir == null) rsp_dir = std.fs.path.dirname(path) orelse ".";
+            if (rsp_dir == null and inner.rsp_dir != null) rsp_dir = inner.rsp_dir;
+        } else {
+            try out.append(arena, arg);
+        }
+    }
+    return .{ .items = out.items, .rsp_dir = rsp_dir };
+}
+
+/// Splits one response file line into arguments: whitespace separates,
+/// double quotes group (also mid-token, as in /NATVIS:"path with spaces").
+fn tokenizeLine(arena: Allocator, line: []const u8, out: *Args) !void {
+    var token: std.ArrayList(u8) = .empty;
+    var in_token = false;
+    var in_quotes = false;
+    for (line) |c| {
+        if (c == '"') {
+            in_quotes = !in_quotes;
+            in_token = true;
+            continue;
+        }
+        if (!in_quotes and (c == ' ' or c == '\t')) {
+            if (in_token) {
+                try out.append(arena, try token.toOwnedSlice(arena));
+                in_token = false;
+            }
+            continue;
+        }
+        try token.append(arena, c);
+        in_token = true;
+    }
+    if (in_token) try out.append(arena, try token.toOwnedSlice(arena));
+}
+
+// --- Translation -------------------------------------------------------------
+
+const Translation = struct {
+    /// zig cc arguments, in input order.
+    args: Args = .empty,
+    warnings: Args = .empty,
+    out_path: ?[]const u8 = null,
+    saw_target: bool = false,
+};
+
+/// MSVC options that have no effect on (or no equivalent in) an lld MinGW
+/// link and are dropped without a warning. Matched on the option name alone
+/// or the name followed by ':'.
+const silently_dropped = [_][]const u8{
+    "NOLOGO",      "MANIFEST",          "MANIFESTUAC", "MANIFESTFILE", "INCREMENTAL",
+    "NOEXP",       "NOIMPLIB",          "IGNORE",      "NATVIS",       "SOURCELINK",
+    "CETCOMPAT",   "GUARD",             "SAFESEH",     "NODEFAULTLIB", "DEFAULTLIB",
+    "MACHINE",     "PDB",               "PDBALTPATH",  "BASE",         "DYNAMICBASE",
+    "NXCOMPAT",    "HIGHENTROPYVA",     "FIXED",       "TSAWARE",      "MAP",
+    "VERBOSE",     "WX",                "TIME",        "ERRORREPORT",  "LARGEADDRESSAWARE",
+    "RELEASE",     "DEBUGTYPE",
+};
+
+/// Translates MSVC link.exe arguments to `zig cc` arguments. Pure argument
+/// rewriting; support-file emission and process launch live in `run`.
+fn translate(arena: Allocator, tokens: []const []const u8) !Translation {
+    var t: Translation = .{};
+    var merge_note_emitted = false;
+    var debug_emitted = false;
+
+    for (tokens) |token| {
+        if (token.len == 0) continue;
+
+        // The target triple line Crosscompile.targets injects via LinkerArg.
+        if (std.mem.startsWith(u8, token, "--target=")) {
+            try t.args.append(arena, token);
+            t.saw_target = true;
+            continue;
+        }
+
+        if (token[0] == '/' or token[0] == '-') {
+            const opt = token[1..];
+            if (optPayload(opt, "OUT")) |out| {
+                try t.args.appendSlice(arena, &.{ "-o", out });
+                t.out_path = out;
+                continue;
+            }
+            if (optPayload(opt, "DEF")) |def| {
+                // lld accepts a module-definition file as a regular input.
+                try t.args.append(arena, def);
+                continue;
+            }
+            if (std.ascii.eqlIgnoreCase(opt, "DLL")) {
+                try t.args.append(arena, "-shared");
+                continue;
+            }
+            if (optPayload(opt, "LIBPATH")) |dir| {
+                try t.args.append(arena, try std.fmt.allocPrint(arena, "-L{s}", .{dir}));
+                continue;
+            }
+            if (optPayload(opt, "SUBSYSTEM")) |subsystem| {
+                // /SUBSYSTEM:CONSOLE[,major[.minor]] - version suffix dropped.
+                const name = subsystem[0 .. std.mem.indexOfScalar(u8, subsystem, ',') orelse subsystem.len];
+                const lower = try std.ascii.allocLowerString(arena, name);
+                try t.args.append(arena, try std.fmt.allocPrint(arena, "-Wl,--subsystem,{s}", .{lower}));
+                continue;
+            }
+            if (optPayload(opt, "ENTRY")) |entry| {
+                if (std.ascii.eqlIgnoreCase(entry, "wmainCRTStartup")) {
+                    // The MinGW CRT provides its own wmainCRTStartup (which
+                    // calls the wmain the NativeAOT bootstrapper defines);
+                    // -municode swaps it in.
+                    try t.args.append(arena, "-municode");
+                } else if (!std.ascii.eqlIgnoreCase(entry, "mainCRTStartup")) {
+                    try t.args.append(arena, try std.fmt.allocPrint(arena, "-Wl,--entry,{s}", .{entry}));
+                }
+                continue;
+            }
+            if (optPayload(opt, "STACK")) |stack| {
+                // /STACK:reserve[,commit] - lld sizes the commit itself.
+                const reserve = stack[0 .. std.mem.indexOfScalar(u8, stack, ',') orelse stack.len];
+                try t.args.append(arena, try std.fmt.allocPrint(arena, "-Wl,--stack,{s}", .{reserve}));
+                continue;
+            }
+            if (optPayload(opt, "INCLUDE")) |symbol| {
+                try t.args.append(arena, try std.fmt.allocPrint(arena, "-Wl,-u,{s}", .{symbol}));
+                continue;
+            }
+            if (std.ascii.eqlIgnoreCase(opt, "DEBUG") or optPayload(opt, "DEBUG") != null) {
+                if (!debug_emitted) try t.args.append(arena, "-g"); // lld writes <output-base>.pdb
+                debug_emitted = true;
+                continue;
+            }
+            if (optPayload(opt, "OPT")) |what| {
+                if (std.ascii.eqlIgnoreCase(what, "REF"))
+                    try t.args.append(arena, "-Wl,--gc-sections");
+                continue; // ICF and friends: lld's defaults apply
+            }
+            if (optPayload(opt, "MERGE") != null) {
+                if (!merge_note_emitted)
+                    try t.warnings.append(arena, "[link shim] Note: /MERGE is not supported by the MinGW driver; sections are left unmerged (slightly larger output, same behavior).");
+                merge_note_emitted = true;
+                continue;
+            }
+            if (isDropped(opt)) continue;
+
+            // Not a recognized option. MSVC options and absolute Unix paths
+            // both start with '/': treat it as an option (warn and drop) only
+            // when it looks like one - a leading alphabetic name followed by
+            // ':' or nothing - and as an input path otherwise.
+            if (token[0] == '/' and !looksLikeOption(opt)) {
+                try t.args.append(arena, token);
+                continue;
+            }
+            try t.warnings.append(arena, try std.fmt.allocPrint(arena, "[link shim] Warning: dropping unsupported linker option '{s}'.", .{token}));
+            continue;
+        }
+
+        // Positional input. Bare import-library names (kernel32.lib) become
+        // -l lookups into zig's bundled MinGW libs; anything with a path
+        // stays a file input (the MSVC-built COFF archives link as-is).
+        if (std.ascii.endsWithIgnoreCase(token, ".lib") and std.mem.indexOfAny(u8, token, "/\\") == null) {
+            const base = token[0 .. token.len - ".lib".len];
+            try t.args.append(arena, try std.fmt.allocPrint(arena, "-l{s}", .{try std.ascii.allocLowerString(arena, base)}));
+            continue;
+        }
+        try t.args.append(arena, token);
+    }
+
+    return t;
+}
+
+/// "OUT:x" with name "OUT" gives "x"; case-insensitive; null when the
+/// option name does not match or has no payload.
+fn optPayload(opt: []const u8, comptime name: []const u8) ?[]const u8 {
+    if (opt.len <= name.len + 1) return null;
+    if (!std.ascii.eqlIgnoreCase(opt[0..name.len], name)) return null;
+    if (opt[name.len] != ':') return null;
+    return opt[name.len + 1 ..];
+}
+
+fn isDropped(opt: []const u8) bool {
+    for (silently_dropped) |name| {
+        if (std.ascii.eqlIgnoreCase(opt, name)) return true;
+        if (opt.len > name.len and opt[name.len] == ':' and std.ascii.eqlIgnoreCase(opt[0..name.len], name)) return true;
+    }
+    return false;
+}
+
+/// Heuristic separating unknown MSVC options from absolute Unix paths:
+/// an option is an alphabetic name, optionally followed by ':' and a
+/// payload; a path has more separators or non-alphabetic components.
+fn looksLikeOption(opt: []const u8) bool {
+    const name_end = std.mem.indexOfScalar(u8, opt, ':') orelse opt.len;
+    if (name_end == 0) return false;
+    for (opt[0..name_end]) |c| {
+        if (!std.ascii.isAlphabetic(c)) return false;
+    }
+    return true;
+}
+
+// --- Support files -----------------------------------------------------------
+
+const glue_file_name = "aotanywhere-msvc-glue.c";
+const stub_dir_name = "aotanywhere-msvc-stub-libs";
+
+/// The MSVC objects carry /DEFAULTLIB directives for these MSVC-only
+/// libraries. Empty archives satisfy the directive; the MinGW CRT and the
+/// glue source provide the symbols instead. (lld's MinGW driver searches
+/// the lib<name>.a spelling, preserving the directive's case.)
+const stub_lib_names = [_][]const u8{ "libLIBCMT.a", "libOLDNAMES.a", "liblibcpmt.a", "libuuid.a" };
+const empty_archive = "!<arch>\n";
+
+/// Writes the glue source and the stub archive directory into support_dir;
+/// returns the glue source path to add to the link.
+fn writeSupportFiles(arena: Allocator, io: std.Io, support_dir: []const u8) ![]const u8 {
+    const cwd = std.Io.Dir.cwd();
+
+    const stub_dir = try std.fs.path.join(arena, &.{ support_dir, stub_dir_name });
+    try cwd.createDirPath(io, stub_dir);
+    for (stub_lib_names) |name| {
+        const path = try std.fs.path.join(arena, &.{ stub_dir, name });
+        const file = try cwd.createFile(io, path, .{});
+        defer file.close(io);
+        try file.writeStreamingAll(io, empty_archive);
+    }
+
+    const glue_path = try std.fs.path.join(arena, &.{ support_dir, glue_file_name });
+    const glue = try cwd.createFile(io, glue_path, .{});
+    defer glue.close(io);
+    try glue.writeStreamingAll(io, glue_source);
+    return glue_path;
+}
+
+// --- Process launch ----------------------------------------------------------
+
+fn say(io: std.Io, comptime fmt: []const u8, args: anytype) void {
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt ++ "\n", args) catch return;
+    std.Io.File.stdout().writeStreamingAll(io, msg) catch {};
+}
+
+fn fatal(io: std.Io, comptime fmt: []const u8, args: anytype) noreturn {
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, "link (AotAnywhere shim): error: " ++ fmt ++ "\n", args) catch
+        "link (AotAnywhere shim): error\n";
+    std.Io.File.stderr().writeStreamingAll(io, msg) catch {};
+    std.process.exit(1);
+}
+
+fn execZigCc(io: std.Io, argv: []const []const u8) noreturn {
+    if (std.process.can_replace) {
+        // Replace the process image so zig's exit code (or signal) is
+        // observed directly by the caller.
+        const err = std.process.replace(io, .{ .argv = argv });
+        reportSpawnError(err);
+    } else run: {
+        // Windows: spawn zig and forward its exit code.
+        var child = std.process.spawn(io, .{ .argv = argv }) catch |err| {
+            reportSpawnError(err);
+            break :run;
+        };
+        const term = child.wait(io) catch |err| {
+            reportSpawnError(err);
+            break :run;
+        };
+        switch (term) {
+            .exited => |code| std.process.exit(code),
+            else => std.process.exit(1),
+        }
+    }
+    std.process.exit(127);
+}
+
+fn reportSpawnError(err: anyerror) void {
+    if (err == error.FileNotFound) {
+        std.debug.print("Error: zig is not on the PATH.\n", .{});
+    } else {
+        std.debug.print("Error: failed to run zig: {s}\n", .{@errorName(err)});
+    }
+}
+
+// --- MSVC glue ---------------------------------------------------------------
+
+/// Compiled into every Windows link (zig cc compiles it alongside the
+/// objects). Bridges what the MSVC-built NativeAOT runtime libraries expect
+/// from the MSVC CRT onto the MinGW CRT. Verified against the .NET 8 and
+/// .NET 10 runtime packs for win-x64 and win-arm64.
+const glue_source =
+    \\/* Generated by the AotAnywhere link shim.
+    \\   Glue for linking MSVC-built NativeAOT runtime libs with the MinGW CRT. */
+    \\#include <stdlib.h>
+    \\#include <stdint.h>
+    \\
+    \\/* MSVC /GS stack cookie support (normally in LIBCMT). The cookie stays at
+    \\   its default value: MinGW startup never calls __security_init_cookie, so
+    \\   checks are consistent, just not randomized. */
+    \\uintptr_t __security_cookie = 0x00002B992DDFA232ULL;
+    \\uintptr_t __security_cookie_complement = ~0x00002B992DDFA232ULL;
+    \\
+    \\void __security_check_cookie(uintptr_t cookie)
+    \\{
+    \\    if (cookie != __security_cookie)
+    \\        __builtin_trap();
+    \\}
+    \\
+    \\/* SEH personality for /GS frames, referenced from unwind data. The real one
+    \\   validates the cookie during unwind; continuing the search preserves EH
+    \\   semantics. EXCEPTION_DISPOSITION ExceptionContinueSearch == 1. */
+    \\int __GSHandlerCheck(void *rec, void *frame, void *ctx, void *disp)
+    \\{
+    \\    (void)rec; (void)frame; (void)ctx; (void)disp;
+    \\    return 1;
+    \\}
+    \\
+    \\/* MSVC marker symbol pulled in by objects using floating point. */
+    \\int _fltused = 0x9875;
+    \\
+    \\/* MSVC ISA dispatch level (normally set by CRT startup). 0 selects the
+    \\   baseline paths in MSVC-compiled dispatch code, which is always safe. */
+    \\int __isa_available = 0;
+    \\
+    \\/* MSVC stack range check failure (emitted for large local arrays). */
+    \\__attribute__((noreturn)) void __report_rangecheckfailure(void)
+    \\{
+    \\    __builtin_trap();
+    \\}
+    \\
+    \\/* MSVC 2019+ on-demand TLS init scheme (/Zc:tlsGuards). The guard is itself
+    \\   thread-local; initializing it to 1 marks TLS as "already initialized" in
+    \\   every thread, so the on-demand path never runs. The NativeAOT runtime's
+    \\   thread-locals have no dynamic initializers, so nothing is lost. */
+    \\__thread char __tls_guard = 1;
+    \\
+    \\void __dyn_tls_on_demand_init(void)
+    \\{
+    \\}
+    \\
+    \\#if defined(__x86_64__)
+    \\/* Control Flow Guard dispatch fallback: mingw's cfguard support object takes
+    \\   the address of this dummy, but zig's mingw bundle does not provide it.
+    \\   When no CFG-aware loader rewrites the pointer, dispatch jumps to the
+    \\   target address (x64: rax, arm64: x15). */
+    \\__attribute__((naked)) void __guard_dispatch_icall_dummy(void)
+    \\{
+    \\    __asm__("jmpq *%rax");
+    \\}
+    \\#elif defined(__aarch64__)
+    \\__attribute__((naked)) void __guard_dispatch_icall_dummy(void)
+    \\{
+    \\    __asm__("br x15");
+    \\}
+    \\#endif
+    \\
+    \\#if defined(__aarch64__)
+    \\/* MSVC arm64 emits out-of-line calls for these Interlocked helpers (x64
+    \\   always inlines them). They interoperate with inlined ldaxp/stlxp
+    \\   sequences elsewhere, so they must be genuinely lock-free; on aarch64
+    \\   the __atomic builtins compile to inline exclusive-pair loops. */
+    \\long _InterlockedAnd(volatile long *p, long v) { return __atomic_fetch_and(p, v, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedOr(volatile long *p, long v) { return __atomic_fetch_or(p, v, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedXor(volatile long *p, long v) { return __atomic_fetch_xor(p, v, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedExchange(volatile long *p, long v) { return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedExchangeAdd(volatile long *p, long v) { return __atomic_fetch_add(p, v, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedIncrement(volatile long *p) { return __atomic_add_fetch(p, 1, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedDecrement(volatile long *p) { return __atomic_sub_fetch(p, 1, __ATOMIC_SEQ_CST); }
+    \\long _InterlockedCompareExchange(volatile long *p, long exch, long cmp)
+    \\{
+    \\    __atomic_compare_exchange_n(p, &cmp, exch, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    \\    return cmp;
+    \\}
+    \\long long _InterlockedExchange64(volatile long long *p, long long v) { return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedExchangeAdd64(volatile long long *p, long long v) { return __atomic_fetch_add(p, v, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedAnd64(volatile long long *p, long long v) { return __atomic_fetch_and(p, v, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedOr64(volatile long long *p, long long v) { return __atomic_fetch_or(p, v, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedIncrement64(volatile long long *p) { return __atomic_add_fetch(p, 1, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedDecrement64(volatile long long *p) { return __atomic_sub_fetch(p, 1, __ATOMIC_SEQ_CST); }
+    \\long long _InterlockedCompareExchange64(volatile long long *p, long long exch, long long cmp)
+    \\{
+    \\    __atomic_compare_exchange_n(p, &cmp, exch, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    \\    return cmp;
+    \\}
+    \\void *_InterlockedExchangePointer(void *volatile *p, void *v) { return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST); }
+    \\void *_InterlockedCompareExchangePointer(void *volatile *p, void *exch, void *cmp)
+    \\{
+    \\    __atomic_compare_exchange_n(p, &cmp, exch, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    \\    return cmp;
+    \\}
+    \\
+    \\unsigned char _InterlockedCompareExchange128(volatile long long *dst,
+    \\    long long exch_high, long long exch_low, long long *comparand)
+    \\{
+    \\    unsigned __int128 cmp = ((unsigned __int128)(unsigned long long)comparand[1] << 64)
+    \\                          | (unsigned long long)comparand[0];
+    \\    unsigned __int128 exch = ((unsigned __int128)(unsigned long long)exch_high << 64)
+    \\                           | (unsigned long long)exch_low;
+    \\    unsigned __int128 old = cmp;
+    \\    int ok = __atomic_compare_exchange_n((unsigned __int128 *)dst, &old, exch, 0,
+    \\                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    \\    comparand[0] = (long long)(unsigned long long)old;
+    \\    comparand[1] = (long long)(unsigned long long)(old >> 64);
+    \\    return (unsigned char)ok;
+    \\}
+    \\
+    \\/* MSVC arm64 /GS prologue/epilogue helpers (crt/arm64/secpushpop.asm): the
+    \\   callee allocates a 16-byte slot holding (sp - __security_cookie) and the
+    \\   caller relies on that exact sp adjustment. x16/x17 are the only scratch
+    \\   registers safe here. */
+    \\__asm__(
+    \\    "  .text\n"
+    \\    "  .globl __security_push_cookie\n"
+    \\    "__security_push_cookie:\n"
+    \\    "  sub  sp, sp, #16\n"
+    \\    "  adrp x17, __security_cookie\n"
+    \\    "  ldr  x17, [x17, :lo12:__security_cookie]\n"
+    \\    "  sub  x17, sp, x17\n"
+    \\    "  str  x17, [sp, #8]\n"
+    \\    "  ret\n"
+    \\    "  .globl __security_pop_cookie\n"
+    \\    "__security_pop_cookie:\n"
+    \\    "  adrp x17, __security_cookie\n"
+    \\    "  ldr  x16, [sp, #8]\n"
+    \\    "  ldr  x17, [x17, :lo12:__security_cookie]\n"
+    \\    "  sub  x16, sp, x16\n"
+    \\    "  cmp  x16, x17\n"
+    \\    "  b.ne 1f\n"
+    \\    "  add  sp, sp, #16\n"
+    \\    "  ret\n"
+    \\    "1:\n"
+    \\    "  brk  #0xF001\n");
+    \\#endif
+    \\
+    \\/* MSVC-mangled C++ operator new/delete and std::nothrow (normally from the
+    \\   MSVC C++ runtime), backed by the MinGW CRT heap. */
+    \\void *aa_msvc_new(size_t) __asm__("??2@YAPEAX_K@Z");
+    \\void *aa_msvc_new(size_t n) { void *p = malloc(n); if (!p) __builtin_trap(); return p; }
+    \\
+    \\void *aa_msvc_new_nothrow(size_t, const void *) __asm__("??2@YAPEAX_KAEBUnothrow_t@std@@@Z");
+    \\void *aa_msvc_new_nothrow(size_t n, const void *nt) { (void)nt; return malloc(n); }
+    \\
+    \\void *aa_msvc_new_arr(size_t) __asm__("??_U@YAPEAX_K@Z");
+    \\void *aa_msvc_new_arr(size_t n) { void *p = malloc(n); if (!p) __builtin_trap(); return p; }
+    \\
+    \\void *aa_msvc_new_arr_nothrow(size_t, const void *) __asm__("??_U@YAPEAX_KAEBUnothrow_t@std@@@Z");
+    \\void *aa_msvc_new_arr_nothrow(size_t n, const void *nt) { (void)nt; return malloc(n); }
+    \\
+    \\void aa_msvc_delete(void *) __asm__("??3@YAXPEAX@Z");
+    \\void aa_msvc_delete(void *p) { free(p); }
+    \\
+    \\void aa_msvc_delete_sized(void *, size_t) __asm__("??3@YAXPEAX_K@Z");
+    \\void aa_msvc_delete_sized(void *p, size_t n) { (void)n; free(p); }
+    \\
+    \\void aa_msvc_delete_arr(void *) __asm__("??_V@YAXPEAX@Z");
+    \\void aa_msvc_delete_arr(void *p) { free(p); }
+    \\
+    \\void aa_msvc_delete_arr_sized(void *, size_t) __asm__("??_V@YAXPEAX_K@Z");
+    \\void aa_msvc_delete_arr_sized(void *p, size_t n) { (void)n; free(p); }
+    \\
+    \\const char aa_msvc_nothrow __asm__("?nothrow@std@@3Unothrow_t@1@B") = 0;
+    \\
+;
+
+// --- Tests -------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "link invocations are detected by executable name" {
+    try testing.expect(isLinkInvocation("link"));
+    try testing.expect(isLinkInvocation("link.exe"));
+    try testing.expect(isLinkInvocation("LINK.EXE"));
+    try testing.expect(isLinkInvocation("/usr/local/bin/link"));
+    try testing.expect(isLinkInvocation("C:\\tools\\link.exe"));
+    try testing.expect(!isLinkInvocation("clang"));
+    try testing.expect(!isLinkInvocation("llvm-objcopy"));
+    try testing.expect(!isLinkInvocation("ld.lld"));
+    // A directory containing "link" must not trip the check.
+    try testing.expect(!isLinkInvocation("/opt/link/clang"));
+    try testing.expect(!isLinkInvocation("golink"));
+}
+
+fn expectArgs(expected: []const []const u8, actual: []const []const u8) !void {
+    try testing.expectEqual(expected.len, actual.len);
+    for (expected, actual) |e, a| try testing.expectEqualStrings(e, a);
+}
+
+test "response file lines tokenize with quotes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var out: Args = .empty;
+    try tokenizeLine(arena, "\"obj/native/Hello.obj\"", &out);
+    try tokenizeLine(arena, "/NOLOGO /MANIFEST:NO", &out);
+    try tokenizeLine(arena, "/NATVIS:\"/path with spaces/NativeAOT.natvis\"", &out);
+    try tokenizeLine(arena, "  ", &out);
+    try expectArgs(&.{
+        "obj/native/Hello.obj",
+        "/NOLOGO",
+        "/MANIFEST:NO",
+        "/NATVIS:/path with spaces/NativeAOT.natvis",
+    }, out.items);
+}
+
+const FakeReader = struct {
+    path: []const u8,
+    contents: []const u8,
+
+    fn read(self: FakeReader, arena: Allocator, path: []const u8) ![]u8 {
+        if (!std.mem.eql(u8, path, self.path)) return error.FileNotFound;
+        return arena.dupe(u8, self.contents);
+    }
+};
+
+test "response files expand with BOM and CRLF" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const reader = FakeReader{
+        .path = "obj/native/link.rsp",
+        .contents = "\xEF\xBB\xBF\"Hello.obj\"\r\n/OUT:\"bin/Hello.exe\"\r\n/NOLOGO /NOEXP\r\n",
+    };
+    const expanded = try expandResponseFiles(arena, reader, &.{"@obj/native/link.rsp"}, 0);
+    try expectArgs(&.{ "Hello.obj", "/OUT:bin/Hello.exe", "/NOLOGO", "/NOEXP" }, expanded.items);
+    try testing.expectEqualStrings("obj/native", expanded.rsp_dir.?);
+
+    const utf16 = FakeReader{ .path = "a.rsp", .contents = "\xFF\xFEx" };
+    try testing.expectError(error.Utf16ResponseFileUnsupported, expandResponseFiles(arena, utf16, &.{"@a.rsp"}, 0));
+}
+
+test "translates the ILC windows link response file" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Condensed from a real net10 link.rsp, plus the injected --target line.
+    const t = try translate(arena, &.{
+        "obj/native/Hello.obj",
+        "/OUT:bin/native/Hello.exe",
+        "/DEF:obj/native/Hello.def",
+        "/Users/u/.nuget/packages/pack/sdk/bootstrapper.obj",
+        "/Users/u/.nuget/packages/pack/sdk/Runtime.WorkstationGC.lib",
+        "advapi32.lib",
+        "kernel32.lib",
+        "/NOLOGO",
+        "/MANIFEST:NO",
+        "/MERGE:.managedcode=.text",
+        "/MERGE:hydrated=.bss",
+        "/DEBUG",
+        "/INCREMENTAL:NO",
+        "/SUBSYSTEM:CONSOLE",
+        "/ENTRY:wmainCRTStartup",
+        "/NOEXP",
+        "/NOIMPLIB",
+        "/STACK:1572864",
+        "/NATVIS:/Users/u/.nuget/packages/ilc/build/NativeAOT.natvis",
+        "/IGNORE:4104",
+        "/CETCOMPAT",
+        "/NODEFAULTLIB:libucrt.lib",
+        "/DEFAULTLIB:ucrt.lib",
+        "/OPT:REF",
+        "/OPT:ICF",
+        "--target=x86_64-windows-gnu",
+    });
+
+    try expectArgs(&.{
+        "obj/native/Hello.obj",
+        "-o",
+        "bin/native/Hello.exe",
+        "obj/native/Hello.def",
+        "/Users/u/.nuget/packages/pack/sdk/bootstrapper.obj",
+        "/Users/u/.nuget/packages/pack/sdk/Runtime.WorkstationGC.lib",
+        "-ladvapi32",
+        "-lkernel32",
+        "-g",
+        "-Wl,--subsystem,console",
+        "-municode",
+        "-Wl,--stack,1572864",
+        "-Wl,--gc-sections",
+        "--target=x86_64-windows-gnu",
+    }, t.args.items);
+    try testing.expect(t.saw_target);
+    try testing.expectEqualStrings("bin/native/Hello.exe", t.out_path.?);
+    // The only warning is the /MERGE note, emitted once for two /MERGE args.
+    try testing.expectEqual(@as(usize, 1), t.warnings.items.len);
+}
+
+test "translates DLL, INCLUDE, custom entry and libpath" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const t = try translate(arena, &.{
+        "/DLL",
+        "/OUT:bin/native/Lib.dll",
+        "/INCLUDE:MyExport",
+        "/ENTRY:MyStartup",
+        "/LIBPATH:/opt/libs",
+        "/SUBSYSTEM:WINDOWS,6.0",
+    });
+    try expectArgs(&.{
+        "-shared",
+        "-o",
+        "bin/native/Lib.dll",
+        "-Wl,-u,MyExport",
+        "-Wl,--entry,MyStartup",
+        "-L/opt/libs",
+        "-Wl,--subsystem,windows",
+    }, t.args.items);
+    try testing.expectEqual(@as(usize, 0), t.warnings.items.len);
+}
+
+test "mainCRTStartup entry needs no flag and DEBUG variants emit one -g" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const t = try translate(arena, &.{ "/ENTRY:mainCRTStartup", "/DEBUG:FULL", "/DEBUG" });
+    try expectArgs(&.{"-g"}, t.args.items);
+}
+
+test "unknown options warn and drop, absolute paths pass through" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const t = try translate(arena, &.{
+        "/PROFILE",
+        "/DELAYLOAD:foo.dll",
+        "/Users/u/objs/thing.obj",
+        "relative/path.lib",
+        "UPPER.LIB",
+    });
+    try expectArgs(&.{
+        "/Users/u/objs/thing.obj",
+        "relative/path.lib",
+        "-lupper",
+    }, t.args.items);
+    try testing.expectEqual(@as(usize, 2), t.warnings.items.len);
+}
+
+test "option payload parsing is case-insensitive" {
+    try testing.expectEqualStrings("x", optPayload("out:x", "OUT").?);
+    try testing.expectEqualStrings("x", optPayload("OUT:x", "OUT").?);
+    try testing.expectEqual(null, optPayload("OUT:", "OUT"));
+    try testing.expectEqual(null, optPayload("OUTX:x", "OUT"));
+    try testing.expect(isDropped("nologo"));
+    try testing.expect(isDropped("IGNORE:4104"));
+    try testing.expect(!isDropped("IGNOREX"));
+    try testing.expect(looksLikeOption("PROFILE"));
+    try testing.expect(looksLikeOption("DELAYLOAD:foo.dll"));
+    try testing.expect(!looksLikeOption("Users/u/x.obj"));
+    try testing.expect(!looksLikeOption("tmp/x"));
+}


### PR DESCRIPTION
## What

Adds `win-x64` and `win-arm64` as publish targets from Linux and macOS hosts, completing the matrix: every supported host can now target Linux, macOS **and Windows**. On a Windows host the package stays inert for `win-*` RIDs and the SDK's native MSVC link applies.

Upstream PublishAotCross ruled this out ("not possible … due to ABI differences (MSVC vs. MingW ABI)"). It turns out the official MSVC-built runtime packs *do* link and stand up under zig's MinGW-w64/UCRT toolchain — the ABI gaps are finite and bridgeable at link time.

## How

The multi-call shim gains a third personality, `link` (`src/link_shim.zig`):

- Expands the MSVC-style `link @rsp` response file the ILC targets write (UTF-8 BOM, quoted tokens), translates the options to GNU spellings (`/OUT:`→`-o`, `/SUBSYSTEM`→`--subsystem`, `/STACK`→`--stack`, `/ENTRY:wmainCRTStartup`→`-municode`, `/DEBUG`→`-g` for a PDB, `/INCLUDE`→`-u`, `/OPT:REF`→`--gc-sections`, `/DLL`→`-shared`, `.def` passthrough) and execs `zig cc -target <arch>-windows-gnu`.
- Writes empty stub archives satisfying the objects' `/DEFAULTLIB` directives for MSVC-only libs (LIBCMT, OLDNAMES, libcpmt, uuid) — the MinGW CRT provides the real C runtime.
- Injects a glue C source supplying the MSVC CRT symbols MinGW lacks: `/GS` stack-cookie support (incl. the arm64 `__security_push_cookie`/`__security_pop_cookie` helpers, faithful to MSVC's `crt/arm64/secpushpop.asm` contract), the `/Zc:tlsGuards` on-demand TLS init scheme, MSVC-mangled `operator new`/`delete` + `std::nothrow`, out-of-line arm64 `_Interlocked*` (lock-free, exclusive-pair based), `_fltused`, `__isa_available`, `__report_rangecheckfailure`, and a CFG dispatch fallback.

`Crosscompile.targets` wires it up for cross-Windows publishes only: skips the ILC targets' vcvarsall probe, points `CppLinker` at the shim, injects the `--target` triple via `LinkerArg`, errors clearly for unsupported win RIDs (win-x86), and copies the lld-produced `.pdb` to the publish directory.

Known trade-offs (documented in the README): `/MERGE`, `/guard:cf` and `/CETCOMPAT` are dropped (zig can't express them; not needed for correctness), and the GS cookie keeps a fixed value — for maximum-hardening release builds, link on Windows with MSVC.

## Validation

- Locally (macOS arm64 host): linked and published against .NET 8 and .NET 10 runtime packs, both architectures, Workstation and Server GC; Linux/macOS targets re-verified unaffected; 26 zig unit tests incl. new response-file/translation coverage; `pack` and `TestShims` green.
- CI: the validation matrix now builds `win-x64`/`win-arm64` from all five hosts and **executes the binaries on `windows-latest` and `windows-11-arm` runners** — the definitive runtime proof (no wine locally). Windows-host builds go through the untouched native MSVC path, validating package inertness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)