### PR TITLE
Retire the AotAnywhereDirectLink escape hatch

### DIFF
--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -56,19 +56,11 @@ for target in "${TARGET_ARRAY[@]}"; do
   # Pseudo-target decorations select publish variants of the same RID; the
   # artifact directory keeps the decorated name so the validate job can
   # exercise each variant:
-  #   <rid>-shim     - AotAnywhereDirectLink=false, the escape hatch back to
-  #                    the clang-shim link flow (direct zig invocation is the
-  #                    default for Linux targets)
   #   lib-<rid>      - test/HelloLib, a NativeLib=Shared library
   #   <rid>-selftest - Hello with AotAnywhereSelfTest=true: net10.0 and real
   #                    ICU (no InvariantGlobalization), zlib and OpenSSL
   #                    exercised at run time via --selftest
   rid="$target"
-  flow_args=()
-  if [[ "$rid" == *-shim ]]; then
-    rid="${rid%-shim}"
-    flow_args=("-p:AotAnywhereDirectLink=false")
-  fi
 
   project="test/Hello.csproj"
   binary_base="Hello"
@@ -89,32 +81,19 @@ for target in "${TARGET_ARRAY[@]}"; do
     # for Linux targets and is served by the shim's llvm-objcopy
     # personality, so this exercises the strip pipeline on every
     # host x target combination.
-    publish_log="/tmp/publish-$group_id-$target.log"
+    #
+    # No fallback tripwire needed: the clang personality hard-errors on any
+    # Linux link invocation, so a publish that silently routed through the
+    # shim instead of the direct zig link fails outright.
     if dotnet publish "$project" \
       -r "$rid" \
-      ${flow_args[@]+"${flow_args[@]}"} \
       ${variant_args[@]+"${variant_args[@]}"} \
       -c Release \
       -p:BaseIntermediateOutputPath="$obj_dir" \
-      --output "artifacts/$host_name/$target" 2>&1 | tee "$publish_log"; then
+      --output "artifacts/$host_name/$target"; then
 
       echo "✅ Cross-compilation build succeeded for $target"
       build_result="success"
-
-      # Tripwire: the clang personality prints this marker whenever it
-      # handles a Linux link. Default publishes use the direct zig link, so
-      # the marker means a silent fallback to the shim flow; conversely a
-      # -shim escape-hatch publish that lacks the marker did not actually
-      # route through the shim.
-      if [[ "$target" == *-shim ]]; then
-        if ! grep -Fq "clang shim] Detected Linux compilation target" "$publish_log"; then
-          echo "❌ Escape-hatch publish for $target did not go through the clang shim link"
-          build_result="failed"
-        fi
-      elif grep -Fq "clang shim] Detected Linux compilation target" "$publish_log"; then
-        echo "❌ Publish for $target fell back to the clang shim link (direct link is the default)"
-        build_result="failed"
-      fi
     else
       echo "❌ Cross-compilation build failed for $target"
       build_result="failed"

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -264,16 +264,13 @@ jobs:
       # the implicit wait after the whole group finishes, so every target
       # still gets attempted and uploaded.
       - parallel:
-          # All plain Linux targets link via the default direct zig
-          # invocation. The extra linux-x64 variants, spread across the
-          # groups to keep the four streams balanced at 4/3/4/4:
-          #   linux-x64-selftest[-shim]  - net10.0, real ICU/zlib/OpenSSL,
-          #                                exercised at run time
-          #   lib-linux-x64[-shim]       - NativeLib=Shared library
-          #   linux-x64-shim             - plain exe
-          # The -shim variants publish with AotAnywhereDirectLink=false, the
-          # escape hatch back to the clang-shim link flow, keeping that flow
-          # covered for A/B parity until it is retired.
+          # All Linux targets link via the direct zig invocation (the only
+          # Linux link flow; the clang shim hard-errors if a Linux link
+          # reaches it). The extra linux-x64 variants, spread across the
+          # groups to keep the four streams balanced at 4/3/2/3:
+          #   linux-x64-selftest - net10.0, real ICU/zlib/OpenSSL,
+          #                        exercised at run time
+          #   lib-linux-x64      - NativeLib=Shared library
           - name: Build glibc Linux targets
             shell: bash
             env:
@@ -284,16 +281,16 @@ jobs:
             env:
               ZIG_SHIM_DEBUG: "1"
             run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "linux-musl-x64,linux-musl-arm64,linux-musl-arm"
-          - name: Build macOS targets and linux shared libraries
+          - name: Build macOS targets
             shell: bash
             env:
               ZIG_SHIM_DEBUG: "1"
-            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "osx-x64,osx-arm64,lib-linux-x64,lib-linux-x64-shim"
-          - name: Build Windows targets and shim escape hatch
+            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "osx-x64,osx-arm64"
+          - name: Build Windows targets and linux shared library
             shell: bash
             env:
               ZIG_SHIM_DEBUG: "1"
-            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "win-x64,win-arm64,linux-x64-shim,linux-x64-selftest-shim"
+            run: bash .github/scripts/build-targets.sh "${{ matrix.host-name }}" "win-x64,win-arm64,lib-linux-x64"
 
 
       - name: Upload build artifacts
@@ -313,12 +310,12 @@ jobs:
       matrix:
         include:
           # Test x64 binaries on Ubuntu x64. The decorated linux-x64 variants
-          # cover the shim escape hatch (-shim), the shared library (lib-)
-          # loaded via ctypes, and the selftest binary (real ICU, zlib,
-          # OpenSSL) run natively on the runner - each in both link flows.
+          # cover the shared library (lib-) loaded via ctypes and the
+          # selftest binary (real ICU, zlib, OpenSSL) run natively on the
+          # runner.
           - runner: ubuntu-latest
             runner-name: ubuntu-x64
-            test-targets: "linux-x64,linux-musl-x64,linux-x64-shim,lib-linux-x64,lib-linux-x64-shim,linux-x64-selftest,linux-x64-selftest-shim"
+            test-targets: "linux-x64,linux-musl-x64,lib-linux-x64,linux-x64-selftest"
             host-sources: "windows,linux,macos-x64,macos-arm64,linux-arm64"
           # Test ARM64 binaries on Ubuntu ARM64 (now runnable on hosted ARM runners)
           - runner: ubuntu-24.04-arm

--- a/README.md
+++ b/README.md
@@ -200,8 +200,7 @@ link flow: the former `AotAnywhereDirectLink=false` escape hatch back to
 the clang shim was retired after the flows proved equivalent
 (byte-identical output in our shared-library tests). macOS and Windows
 targets always link through the shim personalities. See
-[docs/direct-link-prototype.md](docs/direct-link-prototype.md) for the
-design.
+[docs/direct-link.md](docs/direct-link.md) for the design.
 
 ### Using your own Zig
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Note: Using invariant globalization disables culture-specific formatting, sortin
 
 ### The clang shim
 
-The package materializes a small multi-call shim binary and puts it on `PATH`. Its roles: materialized as `clang` it satisfies the ILC SDK's linker probes and rewrites macOS link invocations to `zig cc` (and Linux ones too, when the `AotAnywhereDirectLink=false` escape hatch routes them this way — the Linux default links zig directly from MSBuild without it); materialized as `llvm-objcopy` it performs the Linux symbol strip; materialized as `link` it stands in for MSVC's linker when targeting Windows from a non-Windows host. The package ships this shim **prebuilt** for the common host RIDs (Windows x86/x64, macOS x64/arm64, Linux x64/arm64) under `build/shim/<host-rid>`, so a normal build just copies it and does no compilation. On any other host the shim is compiled on demand from the bundled `clang_shim.zig` with the Zig toolchain. Pass `/p:UsePrebuiltClangShim=false` to force the compile-on-demand path.
+The package materializes a small multi-call shim binary and puts it on `PATH`. Its roles: materialized as `clang` it satisfies the ILC SDK's linker probes and rewrites macOS link invocations to `zig cc` (Linux links never go through it — they run zig directly from MSBuild, and the shim errors if one reaches it); materialized as `llvm-objcopy` it performs the Linux symbol strip; materialized as `link` it stands in for MSVC's linker when targeting Windows from a non-Windows host. The package ships this shim **prebuilt** for the common host RIDs (Windows x86/x64, macOS x64/arm64, Linux x64/arm64) under `build/shim/<host-rid>`, so a normal build just copies it and does no compilation. On any other host the shim is compiled on demand from the bundled `clang_shim.zig` with the Zig toolchain. Pass `/p:UsePrebuiltClangShim=false` to force the compile-on-demand path.
 
 The prebuilt shims are cross-compiled from a single machine at pack time (see `BuildClangShims` in `AotAnywhere.nuproj`); Zig makes producing all host binaries from one host trivial.
 
@@ -195,12 +195,11 @@ The prebuilt shims are cross-compiled from a single machine at pack time (see `B
 
 Linux targets are linked by invoking `zig cc` directly from MSBuild — the
 SDK still computes everything that goes into the link, and the full zig
-command line is visible in build logs and binlogs. Set
-`/p:AotAnywhereDirectLink=false` to route the link through the clang shim
-instead: that is the previous behavior, kept as an escape hatch while the
-direct flow beds in, and it produces equivalent output (byte-identical in
-our shared-library tests). macOS and Windows targets always link through
-the shim personalities. See
+command line is visible in build logs and binlogs. This is the only Linux
+link flow: the former `AotAnywhereDirectLink=false` escape hatch back to
+the clang shim was retired after the flows proved equivalent
+(byte-identical output in our shared-library tests). macOS and Windows
+targets always link through the shim personalities. See
 [docs/direct-link-prototype.md](docs/direct-link-prototype.md) for the
 design.
 

--- a/docs/cross-platform-validation.md
+++ b/docs/cross-platform-validation.md
@@ -37,14 +37,14 @@ strategy:
       # macos-15-intel and macos-latest hosts
 ```
 
-Beyond the plain RIDs — which link Linux targets via the default direct zig
-invocation — every host also publishes decorated `linux-x64` variants (see
-`build-targets.sh`): `linux-x64-shim` (`AotAnywhereDirectLink=false`, the
-escape hatch back to the clang-shim link flow), `lib-linux-x64[-shim]` (a
+Beyond the plain RIDs — which link Linux targets via the direct zig
+invocation, the only Linux link flow — every host also publishes decorated
+`linux-x64` variants (see `build-targets.sh`): `lib-linux-x64` (a
 `NativeLib=Shared` library, loaded and called via python ctypes during
-validation) and `linux-x64-selftest[-shim]` (a net10.0 build exercising real
-ICU, zlib and OpenSSL at run time via `--selftest`). The `-shim`/plain pairs
-give A/B parity between the two link flows until the shim flow is retired.
+validation) and `linux-x64-selftest` (a net10.0 build exercising real
+ICU, zlib and OpenSSL at run time via `--selftest`). The clang shim
+hard-errors on any Linux link invocation, so a publish that silently
+routed through the retired shim link flow fails outright.
 
 ### 2. Build Process
 For each host-target combination:

--- a/docs/direct-link-prototype.md
+++ b/docs/direct-link-prototype.md
@@ -1,10 +1,11 @@
-# Direct link (`AotAnywhereDirectLink`)
+# Direct link
 
-`src/DirectLink.targets` is the **default link flow for Linux targets**
-(glibc and musl). `/p:AotAnywhereDirectLink=false` is the escape hatch back
-to the clang-shim flow, kept covered in CI (the `-shim` pseudo-targets)
-until it is retired — at which point the shim's Linux rewrite
-(`processLinux`) gets deleted too. macOS and Windows targets always use the
+`src/DirectLink.targets` is the **only link flow for Linux targets**
+(glibc and musl). The `/p:AotAnywhereDirectLink=false` escape hatch back
+to the clang-shim flow — and with it the shim's Linux rewrite
+(`processLinux`) and the `-shim` CI pseudo-targets — was retired once the
+flows had proved equivalent; the clang personality now hard-errors if a
+Linux link ever reaches it. macOS and Windows targets always use the
 shim flows.
 
 This document began as the prototype's design notes; the constraints and
@@ -74,9 +75,9 @@ identical in shape to the shim flow; `LinkNative` confirmed skipping via
 binlog; incremental republish behaves like the shim flow. CI exercised the
 direct flow from every host with execution on the ubuntu-x64 validate job;
 the Windows-host leg (cmd.exe Exec quoting) passed on the first run. After
-the default flip, every plain Linux target in the matrix (glibc/musl,
-x64/arm64/armv7, net8/net9/net10) links via the direct flow, with the
-`-shim` pseudo-targets keeping the escape hatch covered.
+the default flip, every Linux target in the matrix (glibc/musl,
+x64/arm64/armv7, net8/net9/net10) links via the direct flow; the `-shim`
+pseudo-targets kept the escape hatch covered until both were retired.
 
 Bake coverage beyond Hello World, in both flows for A/B parity:
 
@@ -85,8 +86,9 @@ Bake coverage beyond Hello World, in both flows for A/B parity:
   called via ctypes. This surfaced a pre-existing package bug — lld (16+)
   errors on version-script symbols that are not defined (`_init`/`_fini`
   from ILC's generated exports), where GNU ld tolerates them, so net8
-  shared libraries never linked through zig at all. Both flows now add
-  `-Wl,--undefined-version` whenever a version script is used.
+  shared libraries never linked through zig at all. The direct flow adds
+  `-Wl,--undefined-version` whenever a version script is used (the shim's
+  Linux rewrite did too, until it was retired).
 - **Non-trivial app** (`--selftest`, net10, no InvariantGlobalization):
   exercises real ICU (tr-TR casing), zlib (GZip roundtrip through the
   bundled zlib-ng) and OpenSSL (RSA sign/verify) at run time. Both flows

--- a/docs/direct-link.md
+++ b/docs/direct-link.md
@@ -116,4 +116,6 @@ Bake coverage beyond Hello World, in both flows for A/B parity:
 - Removing the PATH prepends and the `AOTANYWHERE_APPLE_SYSROOT`
   process-environment channel.
 - `StaticICULinking`/`StaticOpenSslLinking` invoke `build-local.sh` with
-  `CC=$(CppLinker)`; they keep working only because the shim stays on PATH.
+  `CC=$(CppLinker)`; they keep working only because the shim stays on PATH
+  and forwards compile-only invocations straight to `zig cc` (the Linux
+  hard-error applies to link invocations only).

--- a/src/Crosscompile.targets
+++ b/src/Crosscompile.targets
@@ -244,8 +244,8 @@
   </Target>
   <!-- END: Works around ILCompiler targets not detecting this as a cross compilation -->
 
-  <!-- Direct zig invocation, the default link flow for Linux targets; see
-       the file header there for the design and the escape hatch. -->
+  <!-- Direct zig invocation, the only link flow for Linux targets; see
+       the file header there for the design. -->
   <Import Project="$(MSBuildThisFileDirectory)DirectLink.targets" />
 
   <!-- The SDK's _CopyAotSymbols assumes the host and target symbol layouts

--- a/src/DirectLink.targets
+++ b/src/DirectLink.targets
@@ -1,10 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- The default link flow for Linux targets: link by invoking zig
-       directly instead of having the ILC targets call a clang-impersonating
-       shim found on PATH. AotAnywhereDirectLink=false is the escape hatch
-       back to the shim flow (which remains the flow for macOS and Windows
-       targets, and for NativeLib=Static).
+  <!-- The link flow for Linux targets: link by invoking zig directly
+       instead of having the ILC targets call a clang-impersonating shim
+       found on PATH. This is the only Linux link flow (the
+       AotAnywhereDirectLink=false escape hatch back to the shim was
+       retired); the shim remains the flow for macOS and Windows targets.
+       NativeLib=Static never links through a C compiler at all - the SDK
+       archives with $(CppLibCreator).
 
        The ILC SDK targets remain the source of truth for WHAT to link:
        SetupOSSpecificProps still computes $(NativeObject), @(NativeLibrary)
@@ -23,16 +25,15 @@
        finds its output up to date and skips itself.
 
        Scope: Linux targets (glibc and musl), executables and shared
-       libraries. Other RIDs and NativeLib=Static keep the shim flow.
+       libraries. Other RIDs keep the shim flow.
        SetupOSSpecificProps' linker probes still require the clang shim on
        PATH, so the shim materialization is unchanged; the objcopy
        personality also still performs the symbol strip (zig cannot strip
        ELF), invoked here by absolute path. -->
 
   <PropertyGroup>
-    <AotAnywhereDirectLink Condition="'$(AotAnywhereDirectLink)' == ''">true</AotAnywhereDirectLink>
     <_AotAnywhereDirectLinkActive>false</_AotAnywhereDirectLinkActive>
-    <_AotAnywhereDirectLinkActive Condition="'$(AotAnywhereDirectLink)' == 'true' and $(RuntimeIdentifier.StartsWith('linux')) and '$(NativeLib)' != 'Static'">true</_AotAnywhereDirectLinkActive>
+    <_AotAnywhereDirectLinkActive Condition="$(RuntimeIdentifier.StartsWith('linux')) and '$(NativeLib)' != 'Static'">true</_AotAnywhereDirectLinkActive>
   </PropertyGroup>
 
   <Target Name="AotAnywhereDirectLinkNative"

--- a/src/clang_shim.zig
+++ b/src/clang_shim.zig
@@ -1,6 +1,12 @@
 //! clang_shim.zig - Wrapper that redirects clang invocations to 'zig cc',
 //! adjusting arguments for native compilation and cross-compilation.
 //!
+//! The clang personality translates macOS link invocations only: Linux
+//! links are performed directly from MSBuild (DirectLink.targets), and a
+//! Linux link reaching this shim is an error. The personality still
+//! satisfies the ILC targets' PATH probes and `clang --version` queries
+//! for every target OS.
+//!
 //! This is a multi-call binary: Crosscompile.targets materializes the same
 //! executable as `clang`, `llvm-objcopy` and `link`, and it dispatches on
 //! the name it was invoked as. The objcopy personality (objcopy_shim.zig)
@@ -87,8 +93,14 @@ pub fn main(init: std.process.Init) !void {
             }
         }
     } else {
-        say("[clang shim] Detected Linux compilation target.", .{});
-        try processLinux(arena, &out, args);
+        // Linux links run directly from MSBuild (DirectLink.targets); the
+        // clang personality's Linux path was retired along with the
+        // AotAnywhereDirectLink escape hatch. A Linux link reaching this
+        // shim means AotAnywhereDirectLinkNative did not run - fail loudly
+        // instead of quietly maintaining a duplicate of its zig fixups.
+        std.debug.print("Error: Linux link invocation reached the clang shim; " ++
+            "the direct zig link (AotAnywhereDirectLinkNative) should have handled it.\n", .{});
+        std.process.exit(1);
     }
 
     if (debug) {
@@ -218,38 +230,6 @@ fn processMacosNative(gpa: std.mem.Allocator, out: *Args, args: []const []const 
     }
     if (linksSwiftRuntime(args))
         try out.appendSlice(gpa, &swift_overlay_args);
-}
-
-/// Compiling for Linux.
-fn processLinux(gpa: std.mem.Allocator, out: *Args, args: []const []const u8) !void {
-    // Works around the zig linker dropping necessary parts of the executable.
-    try out.append(gpa, "-Wl,-u,__Module");
-
-    // lld (16+) errors on version-script symbols that are not defined, where
-    // GNU ld tolerates them; ILC's generated exports file assigns _init and
-    // _fini, which zig's shared-library link does not define. Restore GNU
-    // ld's behavior whenever a version script is in play.
-    for (args) |arg| {
-        if (std.mem.startsWith(u8, arg, "-Wl,--version-script=")) {
-            try out.append(gpa, "-Wl,--undefined-version");
-            break;
-        }
-    }
-
-    for (args) |arg| {
-        // zlib is not available with zig; -pie/-Wl,-e0x0 are unsupported.
-        if (matchesAny(arg, &.{ "-lz", "-pie", "-Wl,-pie", "-Wl,-e0x0" })) continue;
-        if (std.mem.eql(u8, arg, "--discard-all")) {
-            try out.append(gpa, "--as-needed");
-            continue;
-        }
-        // Works around a .NET 8 Preview 6 issue (removes single quotes).
-        if (std.mem.eql(u8, arg, "'-Wl,-rpath,$ORIGIN'")) {
-            try out.append(gpa, "-Wl,-rpath,$ORIGIN");
-            continue;
-        }
-        try out.append(gpa, arg);
-    }
 }
 
 const pad_file_name = "aotanywhere-gs-pad.c";
@@ -424,38 +404,6 @@ test "target detection" {
     try testing.expect(detectMacosTarget(&.{ "-framework", "Foundation" }));
     try testing.expect(detectMacosTarget(&.{ "-Wl,-exported_symbols_list", "syms.txt" }));
     try testing.expect(!detectMacosTarget(&.{ "-o", "hello", "--target=x86_64-linux-gnu", "main.o" }));
-}
-
-test "linux filtering" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    var out: Args = .empty;
-    try processLinux(arena, &out, &.{
-        "-o",       "out dir/hello", "--discard-all",        "-lz",    "-pie",
-        "-Wl,-pie", "-Wl,-e0x0",     "'-Wl,-rpath,$ORIGIN'", "main.o",
-    });
-    try expectArgs(&.{
-        "-Wl,-u,__Module", "-o", "out dir/hello", "--as-needed", "-Wl,-rpath,$ORIGIN", "main.o",
-    }, out.items);
-}
-
-test "linux version script gets --undefined-version" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    var out: Args = .empty;
-    try processLinux(arena, &out, &.{
-        "-Wl,--version-script=obj/HelloLib.exports", "-shared", "-o", "HelloLib.so", "main.o",
-    });
-    try expectArgs(&.{
-        "-Wl,-u,__Module",                           "-Wl,--undefined-version",
-        "-Wl,--version-script=obj/HelloLib.exports", "-shared",
-        "-o",                                        "HelloLib.so",
-        "main.o",
-    }, out.items);
 }
 
 test "macos cross-compilation without sysroot drops system libs and frameworks" {

--- a/src/clang_shim.zig
+++ b/src/clang_shim.zig
@@ -5,7 +5,9 @@
 //! links are performed directly from MSBuild (DirectLink.targets), and a
 //! Linux link reaching this shim is an error. The personality still
 //! satisfies the ILC targets' PATH probes and `clang --version` queries
-//! for every target OS.
+//! for every target OS, and forwards compile-only invocations (the
+//! CC=clang glue compiles of StaticICULinking/StaticOpenSslLinking)
+//! straight to zig cc.
 //!
 //! This is a multi-call binary: Crosscompile.targets materializes the same
 //! executable as `clang`, `llvm-objcopy` and `link`, and it dispatches on
@@ -92,6 +94,12 @@ pub fn main(init: std.process.Init) !void {
                 say("Warning: could not write {s}: {s}", .{ pad_path, @errorName(err) });
             }
         }
+    } else if (isCompileInvocation(args)) {
+        // The ILC targets' StaticICULinking/StaticOpenSslLinking path runs
+        // build-local.sh with CC pointed at this shim; plain compiles need
+        // none of the link fixups, so forward them to zig cc untouched.
+        say("[clang shim] Detected compile-only invocation.", .{});
+        try out.appendSlice(arena, args);
     } else {
         // Linux links run directly from MSBuild (DirectLink.targets); the
         // clang personality's Linux path was retired along with the
@@ -131,6 +139,16 @@ fn isQueryInvocation(args: []const []const u8) bool {
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-###"))
             return true;
+    }
+    return false;
+}
+
+/// True for invocations that compile (or preprocess) sources without
+/// linking - the shape build-local.sh produces when the ILC targets compile
+/// the static ICU/OpenSSL glue with CC pointed at the shim.
+fn isCompileInvocation(args: []const []const u8) bool {
+    for (args) |arg| {
+        if (matchesAny(arg, &.{ "-c", "-S", "-E", "-fsyntax-only" })) return true;
     }
     return false;
 }
@@ -395,6 +413,13 @@ test "query invocations pass through untouched" {
     try testing.expect(isQueryInvocation(&.{}));
     try testing.expect(!isQueryInvocation(&.{ "-o", "hello", "main.o" }));
     try testing.expect(!isQueryInvocation(&.{ "-c", "-o", "main.o", "main.c" }));
+}
+
+test "compile-only invocations are detected" {
+    try testing.expect(isCompileInvocation(&.{ "-c", "-o", "pal_icushim.o", "pal_icushim.c" }));
+    try testing.expect(isCompileInvocation(&.{ "-E", "config-probe.c" }));
+    try testing.expect(!isCompileInvocation(&.{ "-o", "hello", "main.o" }));
+    try testing.expect(!isCompileInvocation(&.{ "-shared", "-o", "lib.so", "a.o" }));
 }
 
 test "target detection" {


### PR DESCRIPTION
## What

Step 4 of the direct-link roadmap, pulled forward: with nothing released and no users, there is no one the escape hatch can serve — so retire it now rather than carry two Linux link flows into 1.0.

- **`src/DirectLink.targets`**: the `AotAnywhereDirectLink` property is gone; the direct target activates purely on RID (`linux*`) and `NativeLib != Static`.
- **`src/clang_shim.zig`**: `processLinux` and its tests are deleted. The clang personality's Linux branch now **hard-errors** — a Linux link reaching the shim means `AotAnywhereDirectLinkNative` did not run, and failing loudly beats silently maintaining a duplicate of its zig fixups. (`NativeLib=Static` never hits this path: the SDK archives via `CppLibCreator`, not the C linker.)
- **CI**: the `-shim` pseudo-targets and both marker-grep tripwire polarities are removed — a silent fallback now fails the publish outright via the shim's error. Build streams rebalanced to 4/3/2/3 (`lib-linux-x64` moves to the Windows-targets stream). Validate on ubuntu-x64 drops from 7 to 4 targets × 5 hosts.
- **Docs** (README, `docs/direct-link-prototype.md`, `docs/cross-platform-validation.md`) describe the single flow; the retired hatch is mentioned only as history.

## What stays

The shim binary itself is unchanged in role otherwise: PATH-probe satisfaction, `clang --version` queries, the objcopy ELF strip, and the macOS/Windows target translations all remain.

## Validation (local, macOS arm64 host)

- `dotnet build -t:TestShims` — zig shim unit tests pass against the pinned toolchain
- `linux-x64` exe and `HelloLib.so` (`NativeLib=Shared`) publish via the direct link, `.dbg` sidecars present
- The materialized shim exits 1 with the new diagnostic on a Linux-style link invocation
- `osx-arm64` still links through the shim's macOS path and prints `Hello World`

The full cross-platform matrix runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)