### PR TITLE
Pass zig's absolute path to the shim, dropping the zig PATH prepend

### DIFF
--- a/docs/direct-link.md
+++ b/docs/direct-link.md
@@ -117,9 +117,12 @@ Bake coverage beyond Hello World, in both flows for A/B parity:
   mutation. The `SetupOSSpecificProps` linker/objcopy probes are now
   satisfied by absolute path on non-Windows hosts (`PointLinkerToShim`), so
   the shim's PATH prepend is gone there; Windows hosts still prepend it
-  (their `where /Q` probe cannot take an absolute path), and zig itself
-  remains on PATH on every host, because the shim still execs `zig` by bare
-  name.
+  (their `where /Q` probe cannot take an absolute path). Zig is no longer on
+  PATH either: `SetPathToZig` passes its absolute path to the shim through the
+  `AOTANYWHERE_ZIG` environment variable (and the direct link and shim
+  compilation use `$(_AotAnywhereZigExe)` directly), so the only PATH mutation
+  left is the Windows-host shim prepend. The shim still falls back to a PATH
+  `zig` when `AOTANYWHERE_ZIG` is unset (external zig, degraded restore).
 
 ## Not covered (future work, if the experiment earns it)
 
@@ -128,12 +131,12 @@ Bake coverage beyond Hello World, in both flows for A/B parity:
   translation, MinGW glue, `/MERGE` COFF renames — all link-shim logic).
 - `NativeLib=Static` (the SDK uses `ar` via `CppLibCreator`; untouched —
   the direct-link target conditions itself out and the SDK flow applies).
-- Removing the remaining PATH prepends: the zig one (the shim execs `zig` by
-  bare name; giving it zig's absolute path — e.g. via an env channel or argv
-  — would let `SetPathToZig` drop the prepend) on every host, and the shim
-  one still needed on Windows hosts (whose `where /Q` probe rejects an
-  absolute path). Plus the `AOTANYWHERE_APPLE_SYSROOT` process-environment
-  channel.
+- Removing the last PATH prepend — the shim one still needed on Windows hosts
+  (whose `where /Q` probe rejects an absolute path); it would need a linker
+  resolvable by a colon-free name. Plus collapsing the process-environment
+  channels (`AOTANYWHERE_ZIG`, `AOTANYWHERE_APPLE_SYSROOT`), which trade PATH
+  mutation for a namespaced env var the shim reads — cleaner, but still not
+  zero mutation.
 - `StaticICULinking`/`StaticOpenSslLinking` invoke `build-local.sh` with
   `CC=$(CppLinker)`, now the shim's absolute path (`PointLinkerToShim`);
   they keep working because the shim forwards compile-only invocations

--- a/src/Crosscompile.targets
+++ b/src/Crosscompile.targets
@@ -148,7 +148,7 @@
           Outputs="$(ClangShimBinary);$(ObjCopyShimBinary);$(LinkShimBinary)">
 
     <MakeDir Directories="$(ClangShimDir)" />
-    <Exec Command="zig build-exe -O ReleaseSafe -femit-bin=&quot;$(ClangShimBinary)&quot; &quot;$(ClangShimSource)&quot;" />
+    <Exec Command="&quot;$(_AotAnywhereZigExe)&quot; build-exe -O ReleaseSafe -femit-bin=&quot;$(ClangShimBinary)&quot; &quot;$(ClangShimSource)&quot;" />
     <Copy SourceFiles="$(ClangShimBinary);$(ClangShimBinary)" DestinationFiles="$(ObjCopyShimBinary);$(LinkShimBinary)" OverwriteReadOnlyFiles="true" />
     <Exec Condition="!$([MSBuild]::IsOSPlatform('Windows'))" Command="chmod +x &quot;$(ObjCopyShimBinary)&quot; &quot;$(LinkShimBinary)&quot;" />
 
@@ -225,7 +225,23 @@
     <Error Condition="'$(UseExternalZig)' == 'false' and !Exists('$(ZigPath)')"
            Text="AotAnywhere: the Zig toolset ('Vezel.Zig.Toolsets.$(HostRuntimeIdentifier)' $(ZigVersion)) was not restored. NuGet cannot restore package references declared inside a package's build targets, so a plain PackageReference to StuDev.AotAnywhere does not fetch Zig on a clean machine. Either reference the package as an MSBuild SDK instead — &lt;Sdk Name=&quot;StuDev.AotAnywhere&quot; Version=&quot;&lt;package version&gt;&quot; /&gt; — which restores Zig automatically, or add &lt;PackageReference Include=&quot;Vezel.Zig.Toolsets.$(HostRuntimeIdentifier)&quot; Version=&quot;$(ZigVersion)&quot; PrivateAssets=&quot;all&quot; GeneratePathProperty=&quot;true&quot; /&gt; alongside it, or set UseExternalZig=true with zig on your PATH." />
 
-    <PrependPath Condition="'$(UseExternalZig)' == 'false'" Value="$(ZigPath)" />
+    <!-- The single source of truth for the zig executable, used to compile the
+         shim (CompileClangShim), to link directly (AotAnywhereDirectLinkNative),
+         and by the exec'd shim itself (AOTANYWHERE_ZIG below): an absolute path
+         into the restored toolset, or bare `zig` on PATH when zig is external
+         or the toolset path could not be resolved. -->
+    <PropertyGroup>
+      <_AotAnywhereZigExe>zig</_AotAnywhereZigExe>
+      <_AotAnywhereZigExe Condition="'$(UseExternalZig)' == 'false' and Exists('$(ZigPath)')">$(ZigPath)/zig</_AotAnywhereZigExe>
+      <_AotAnywhereZigExe Condition="'$(UseExternalZig)' == 'false' and Exists('$(ZigPath)') and $([MSBuild]::IsOSPlatform('Windows'))">$(ZigPath)/zig.exe</_AotAnywhereZigExe>
+    </PropertyGroup>
+
+    <!-- The shim (exec'd as the linker for macOS and Windows targets) reads
+         this and execs zig by absolute path, so zig no longer needs its
+         directory prepended to PATH. When it resolves to bare `zig` the shim
+         falls back to a PATH lookup, matching the pre-existing external-zig
+         and degraded-restore behavior. -->
+    <SetEnvVar Name="AOTANYWHERE_ZIG" Value="$(_AotAnywhereZigExe)" />
 
   </Target>
 

--- a/src/DirectLink.targets
+++ b/src/DirectLink.targets
@@ -44,15 +44,10 @@
           Inputs="$(NativeObject);@(NativeLibrary)"
           Outputs="$(NativeBinary)">
 
-    <!-- $(ZigPath) can be a dangling '/tools' when the Vezel package was not
-         part of the restore (the known consumer restore gap); fall back to a
-         PATH zig in that case, matching how the shim flow degrades. -->
-    <PropertyGroup>
-      <_AotAnywhereZigExe>zig</_AotAnywhereZigExe>
-      <_AotAnywhereZigExe Condition="'$(UseExternalZig)' == 'false' and Exists('$(ZigPath)')">$(ZigPath)/zig</_AotAnywhereZigExe>
-      <_AotAnywhereZigExe Condition="'$(UseExternalZig)' == 'false' and Exists('$(ZigPath)') and $([MSBuild]::IsOSPlatform('Windows'))">$(ZigPath)/zig.exe</_AotAnywhereZigExe>
-    </PropertyGroup>
-
+    <!-- $(_AotAnywhereZigExe) is the absolute path to the restored toolset's
+         zig, computed once in SetPathToZig (a DependsOn above); it degrades to
+         a bare PATH `zig` when $(ZigPath) is a dangling '/tools' (the known
+         consumer restore gap), matching how the shim flow degrades. -->
     <ItemGroup>
       <!-- Linker arguments the SDK computes that zig cc cannot take: no libz
            in zig's Linux sysroots (net8 always adds -lz; net9+ link the

--- a/src/clang_shim.zig
+++ b/src/clang_shim.zig
@@ -27,6 +27,9 @@
 //!   ZIG_SHIM_DEBUG                - print original and final argument lists
 //!   AOTANYWHERE_APPLE_SYSROOT - sysroot with Apple framework/library
 //!                                   stubs (.tbd files) for macOS targets
+//!   AOTANYWHERE_ZIG               - absolute path to the zig executable to
+//!                                   exec; falls back to `zig` on PATH when
+//!                                   unset (external-zig or degraded restore)
 //!
 //! Run the unit tests with: zig test clang_shim.zig
 
@@ -58,14 +61,20 @@ pub fn main(init: std.process.Init) !void {
         for (args) |arg| say("  '{s}'", .{arg});
     }
 
+    // The package points this at the restored toolset's zig by absolute path
+    // so no PATH mutation is needed; falls back to `zig` on PATH (external
+    // zig, or a degraded restore where the path could not be resolved).
+    const zig_exe = nonEmpty(init.environ_map.get("AOTANYWHERE_ZIG")) orelse "zig";
+    if (debug) say("[DEBUG] zig executable: '{s}'", .{zig_exe});
+
     if (argv.len > 0 and isObjcopyInvocation(argv[0]))
         objcopy_shim.run(arena, io, args);
 
     if (argv.len > 0 and link_shim.isLinkInvocation(argv[0]))
-        link_shim.run(arena, io, args, debug);
+        link_shim.run(arena, io, args, debug, zig_exe);
 
     var out: Args = .empty;
-    try out.appendSlice(arena, &.{ "zig", "cc" });
+    try out.appendSlice(arena, &.{ zig_exe, "cc" });
 
     if (isQueryInvocation(args)) {
         // Toolchain queries (the ILC targets probe `clang --version` on

--- a/src/link_shim.zig
+++ b/src/link_shim.zig
@@ -42,8 +42,9 @@ pub fn isLinkInvocation(argv0: []const u8) bool {
     return std.ascii.eqlIgnoreCase(base, "link");
 }
 
-/// Entry point when the shim is invoked as link. Never returns.
-pub fn run(arena: Allocator, io: std.Io, args: []const []const u8, debug: bool) noreturn {
+/// Entry point when the shim is invoked as link. Never returns. `zig_exe` is
+/// the zig executable to exec (absolute path from AOTANYWHERE_ZIG, or `zig`).
+pub fn run(arena: Allocator, io: std.Io, args: []const []const u8, debug: bool, zig_exe: []const u8) noreturn {
     const reader = IoFileReader{ .io = io };
     const tokens = expandResponseFiles(arena, reader, args, 0) catch |err|
         fatal(io, "cannot expand response files: {s}", .{@errorName(err)});
@@ -65,7 +66,7 @@ pub fn run(arena: Allocator, io: std.Io, args: []const []const u8, debug: bool) 
         fatal(io, "cannot write support files in '{s}': {s}", .{ support_dir, @errorName(err) });
 
     var argv: Args = .empty;
-    argv.appendSlice(arena, &.{ "zig", "cc" }) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
+    argv.appendSlice(arena, &.{ zig_exe, "cc" }) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
     argv.appendSlice(arena, translation.args.items) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
     argv.append(arena, glue_path) catch |err| fatal(io, "out of memory: {s}", .{@errorName(err)});
     const stub_arg = std.fmt.allocPrint(arena, "-L{s}", .{


### PR DESCRIPTION
## What

Follow-up to #51. After that PR the shim was resolved by absolute path, but the shim *itself* execs `zig` by bare name, so `SetPathToZig` still prepended the toolset directory to `PATH`. This gives the shim zig's absolute path through a namespaced env var instead, and drops the `PrependPath $(ZigPath)`.

- `SetPathToZig` computes `$(_AotAnywhereZigExe)` — an absolute path into the restored toolset (`$(ZigPath)/zig[.exe]`), or bare `zig` for external zig / a degraded restore — and exports it as **`AOTANYWHERE_ZIG`**, mirroring the existing `AOTANYWHERE_APPLE_SYSROOT` channel.
- The clang and link personalities read `AOTANYWHERE_ZIG` and exec that path, falling back to a PATH `zig` when it's unset.
- `$(_AotAnywhereZigExe)` moves from a local block in `DirectLink.targets` to a single definition in `SetPathToZig` (a `DependsOn` of every consumer), so the direct link, the on-demand shim compilation (`CompileClangShim`), and the exec'd shim all agree on one value.

## Why an env var (not zero mutation)

The shim is exec'd by the SDK's `LinkNative`, whose argument list we don't control, so passing the path as an argv flag isn't clean. A namespaced env var the shim alone reads is strictly less invasive than a PATH prepend — it can't shadow other tools in the build. Collapsing the remaining env channels is noted as future work in the design doc; this closes out the *PATH* story on Linux/macOS hosts.

## Result

- **Linux and macOS hosts:** no PATH mutation remains at all.
- **Windows hosts:** the only prepend left is the shim dir, which `where /Q` structurally forces (it can't probe a drive-lettered absolute path — see #51).

## Validation

From a macOS arm64 host:
- `osx-arm64` (native → clang shim) and `win-x64` (cross → link shim) both exec the toolset's zig **by absolute path**, confirmed via `ZIG_SHIM_DEBUG` (`.../vezel.zig.toolsets.osx-arm64/0.16.0.2/tools/zig`), and produce runnable binaries.
- `linux-x64` direct-links to a stripped ELF.
- `UseExternalZig=true` still degrades to a PATH `zig` and builds.
- Shim unit tests pass: `zig test` → clang 28, link 10, objcopy 7.

Full matrix runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)