### PR TITLE
Make publish.yml a dispatchable one-button release (no PAT needed)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,17 +4,11 @@ on:
   pull_request:
     branches: [ master ]
 
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version to create'
-        required: true
-
-# A new push to the same PR supersedes the running build; release dispatches
-# are never cancelled.
+# Releases are driven by publish.yml (dispatch it with a version); this is PR CI
+# only. A new push to the same PR supersedes the running build.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   build_and_test:
@@ -40,8 +34,7 @@ jobs:
           key: nuget-ci-${{ runner.os }}-${{ hashFiles('src/AotAnywhere.nuproj', 'src/Crosscompile.targets', 'test/Hello.csproj') }}
           restore-keys: |
             nuget-ci-${{ runner.os }}-
-      - name: Build (CI)
-        if: ${{ github.event.inputs.version == '' }}
+      - name: Build
         shell: bash
         run: |
           dotnet build -t:Pack src/AotAnywhere.nuproj
@@ -51,25 +44,10 @@ jobs:
           # The strip pipeline must have produced the symbol sidecar.
           test -f test/bin/Release/net8.0/linux-x64/publish/Hello.dbg
       - name: Upload test binary
-        if: ${{ github.event.inputs.version == '' }}
         uses: actions/upload-artifact@v7
         with:
           name: Hello
           path: test/bin/Release/net8.0/linux-x64/publish/Hello
-      - name: Build (CD)
-        if: ${{ github.event.inputs.version != '' }}
-        run: dotnet build -t:Pack src/AotAnywhere.nuproj -p:Version=${{ github.event.inputs.version }}
-      - name: Archive NuGet
-        if: ${{ github.event.inputs.version != '' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: StuDev.AotAnywhere.${{ github.event.inputs.version }}.nupkg
-          path: src/bin/Debug/StuDev.AotAnywhere.${{ github.event.inputs.version }}.nupkg
-      - name: Create tag
-        if: ${{ github.event.inputs.version != '' && github.actor == 'slang25' }}
-        run: |
-          git tag v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
 
   validate:
     needs: build_and_test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,18 @@
 name: Publish to NuGet
 
-# Keyed off the version tag that main.yml's release dispatch pushes, so releases
-# stay one-button: dispatch main.yml with a version -> it tags v<version> ->
-# this workflow validates, packs, and publishes StuDev.AotAnywhere to nuget.org.
+# One-button release: dispatch this workflow with a version -> it validates the
+# full matrix, packs, publishes StuDev.AotAnywhere to nuget.org, then creates the
+# v<version> tag and GitHub release. Dispatched (not tag-triggered) so no PAT is
+# needed: GITHUB_TOKEN can trigger workflow_dispatch (unlike a tag push, which it
+# is blocked from triggering), and the tag is created here after publish so it
+# never needs to trigger anything. A manual `git push` of a v* tag still works as
+# a fallback path.
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (e.g. 1.0.1)'
+        required: true
   push:
     tags:
       - 'v*'
@@ -38,10 +47,24 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      # Version comes from the dispatch input, or from the tag name on the
+      # fallback tag-push path. tag is always v<version>.
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
       - name: Pack
         shell: bash
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ steps.ver.outputs.version }}"
           echo "Packing StuDev.AotAnywhere $version"
           dotnet build -t:Pack src/AotAnywhere.nuproj -p:Version="$version"
           nupkg=$(find src/bin -name "StuDev.AotAnywhere.$version.nupkg" | head -1)
@@ -63,16 +86,20 @@ jobs:
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
 
-      # Attach the published .nupkg to a GitHub release for traceability. Guarded
-      # so a re-run of a partially-completed publish updates the release instead
-      # of failing with a 422 already_exists.
-      - name: Attach package to GitHub release
+      # Tag the published commit and attach the .nupkg to a GitHub release.
+      # On the dispatch path the tag does not exist yet, so create it here
+      # (pointing at this run's commit) - after publish, so it never needs to
+      # trigger anything. On the tag-push path the tag already exists and
+      # `gh release create` reuses it. Guarded so a re-run of a partially
+      # completed publish updates the release instead of failing 422.
+      - name: Tag and attach to GitHub release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" artifacts/*.nupkg --clobber
+          tag="${{ steps.ver.outputs.tag }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" artifacts/*.nupkg --clobber
           else
-            gh release create "$GITHUB_REF_NAME" artifacts/*.nupkg --generate-notes
+            gh release create "$tag" --target "$GITHUB_SHA" --generate-notes artifacts/*.nupkg
           fi


### PR DESCRIPTION
Fixes the two release-workflow bugs found while shipping 1.0.0 — **without needing a PAT.**

## The insight
The root problem was that `main.yml`'s auto-tag step created the tag with the default `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from `GITHUB_TOKEN`-created refs — so `publish.yml` (`on: push: tags`) never fired. My first cut reached for a PAT; that's unnecessary. `GITHUB_TOKEN` **is** allowed to trigger `workflow_dispatch`/`repository_dispatch` (only `push`/`pull_request` are blocked). So the clean fix is to make `publish.yml` itself dispatchable and let it create its own tag *after* publishing — no cross-workflow trigger, no PAT, no secret.

> (The Copilot-CLI changelog I was pointed at is unrelated — it's about Copilot CLI authenticating via `copilot-requests: write`, not workflow triggering. But it prompted the rethink, and the no-PAT answer is better.)

## Changes
**`publish.yml`** becomes the release entry point:
- Adds `workflow_dispatch` with a `version` input (keeps `push: tags` as a fallback path).
- Resolves the version from the input or the tag name.
- After publishing, creates the `v<version>` tag + GitHub release itself via `gh release create --target $GITHUB_SHA`. Created with `GITHUB_TOKEN` *after* the push, so it needs to trigger nothing and can't recurse.
- Trusted-publishing OIDC claims (workflow `publish.yml`, environment `release`) are unchanged.

**`main.yml`** drops its release path entirely (`workflow_dispatch`, `Build (CD)`, `Archive NuGet`, `Create tag`) and is now pure PR CI. This also eliminates the second bug: the "Try launching" validate job used to fail on release dispatches (CD mode produced no `Hello` artifact); it now only runs on PRs.

## Result
One-button release, no secret: **Actions → "Publish to NuGet" → Run workflow → enter `1.0.1`**. It validates the full matrix, publishes to nuget.org, and tags + releases. Manual `git push` of a `v*` tag still works too.

## Validation
Both workflows parse as valid YAML. The dispatch-trigger path can only be exercised by a real release, but `workflow_dispatch` triggering under `GITHUB_TOKEN` is documented GitHub behavior. This PR's own CI exercises the trimmed `main.yml` in PR mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)