### PR TITLE
Bulk-copy the preserved ELF prefix in ElfStripper.RewriteElf

### DIFF
--- a/src/tasks/AotAnywhere.Tasks/ElfStripper.cs
+++ b/src/tasks/AotAnywhere.Tasks/ElfStripper.cs
@@ -248,7 +248,9 @@ public static class ElfStripper
         }
 
         var outBuf = new List<byte>((int)dataEnd + 4096);
-        for (var i = 0; i < (int)dataEnd; i++) outBuf.Add(data[i]);
+        // Bulk-copy the preserved prefix; AddRange takes the ICollection fast
+        // path (a single Array.Copy) rather than a per-byte Add loop.
+        outBuf.AddRange(new ArraySegment<byte>(data, 0, (int)dataEnd));
 
         // .gnu_debuglink payload: NUL-terminated basename padded to 4, then the
         // little-endian CRC32.


### PR DESCRIPTION
Replaces the per-byte `List<byte>.Add` loop that copies the preserved prefix in `ElfStripper.RewriteElf` with a single `AddRange(ArraySegment<byte>)`, which hits `List`'s `ICollection` fast path (one `Array.Copy`) instead of two passes with per-element overhead over a multi-MB native image. Since the task assembly targets `netstandard2.0` there's no `AddRange(ReadOnlySpan<byte>)`, so `ArraySegment` is the idiomatic bulk copy while `outBuf` stays a `List` for the subsequent variable-length appends. Behavior is unchanged and the ElfStripper tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)