### PR TITLE
Release 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SDKs, cross toolchains or system packages to install on the build machine.
    ```xml
    <Project Sdk="Microsoft.NET.Sdk">
 
-     <Sdk Name="StuDev.AotAnywhere" Version="1.0.0-preview.3" />
+     <Sdk Name="StuDev.AotAnywhere" Version="1.0.1" />
    ```
 
    (Or omit the `Version` and pin it once in `global.json` under


### PR DESCRIPTION
Bumps the README Quick start `Sdk` version to `1.0.1` ahead of the 1.0.1 release.

The 1.0.1 package is published by dispatching `publish.yml` with `version=1.0.1` once this lands on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)