### PR TITLE
Bump README Quick start snippet to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SDKs, cross toolchains or system packages to install on the build machine.
    ```xml
    <Project Sdk="Microsoft.NET.Sdk">
 
-     <Sdk Name="StuDev.AotAnywhere" Version="1.0.1" />
+     <Sdk Name="StuDev.AotAnywhere" Version="1.0.2" />
    ```
 
    (Or omit the `Version` and pin it once in `global.json` under


### PR DESCRIPTION
Bumps the Quick start `Sdk` reference version to 1.0.2 ahead of the 1.0.2 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)