### PR TITLE
Bump README Quick start snippet to 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SDKs, cross toolchains or system packages to install on the build machine.
    ```xml
    <Project Sdk="Microsoft.NET.Sdk">
 
-     <Sdk Name="StuDev.AotAnywhere" Version="1.0.2" />
+     <Sdk Name="StuDev.AotAnywhere" Version="1.0.3" />
    ```
 
    (Or omit the `Version` and pin it once in `global.json` under


### PR DESCRIPTION
Prep for the 1.0.3 release: bump the Quick start `Sdk` version snippet from 1.0.2 to 1.0.3.

After merge, dispatch `publish.yml` with version=1.0.3 to validate → pack → publish to nuget.org and create the `v1.0.3` tag + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)