### PR TITLE
Pin zig's cache dirs for the /OPT re-link instead of predicting them

### DIFF
--- a/src/tasks/AotAnywhere.Tasks/AotAnywhereWindowsLink.cs
+++ b/src/tasks/AotAnywhere.Tasks/AotAnywhereWindowsLink.cs
@@ -42,8 +42,8 @@ public sealed class AotAnywhereWindowsLink : MSBuildTask
     const string StubDirName = "aotanywhere-msvc-stub-libs";
     const string OptOutHint = "Set AotAnywhereWindowsLinkOptimize=false to link without /OPT:REF,/OPT:ICF (larger binary).";
 
-    /// Environment overrides for the zig processes (the cache redirects
-    /// AliasSpacedPaths sets up).
+    /// Environment overrides for the zig processes (the cache pins and
+    /// redirects AliasSpacedPaths sets up).
     readonly Dictionary<string, string> _zigEnv = new();
 
     public override bool Execute()
@@ -96,8 +96,17 @@ public sealed class AotAnywhereWindowsLink : MSBuildTask
     /// through space-free symlink aliases keeps the line reconstructible.
     bool AliasSpacedPaths(List<string> argv, MsvcTranslation t, ref string? scratchDir)
     {
-        var cacheDirs = ZigCacheDirsNeedingAlias();
-        if (cacheDirs.Count == 0 && !argv.Any(LinkPathAliaser.HasSpace)) return true;
+        // Pin both cache env vars rather than predict zig's own resolution:
+        // with no override, zig cc roots its local cache at `.zig-cache` under
+        // the nearest ancestor directory holding a build.zig (else the global
+        // dir), and that discovery cannot be reproduced here. Unpinned, a
+        // build.zig ancestor under a spaced path would put the glue object at
+        // a spaced local-cache path this method never saw (issue #67).
+        var cacheDirs = ResolveZigCacheDirs(Environment.GetEnvironmentVariable);
+        foreach (var (variable, dir) in cacheDirs) _zigEnv[variable] = dir;
+
+        var spacedCacheDirs = cacheDirs.Where(c => LinkPathAliaser.HasSpace(c.Dir)).ToList();
+        if (spacedCacheDirs.Count == 0 && !argv.Any(LinkPathAliaser.HasSpace)) return true;
 
         // Hosts are non-Windows only; /tmp is the space-free fallback when the
         // temp dir itself is spaced (TMPDIR override).
@@ -117,7 +126,7 @@ public sealed class AotAnywhereWindowsLink : MSBuildTask
             }
             if (aliasedOut != null) t.OutPath = aliasedOut; // what -OUT: will now say
 
-            foreach (var (variable, dir) in cacheDirs)
+            foreach (var (variable, dir) in spacedCacheDirs)
             {
                 Directory.CreateDirectory(dir); // symlink to a real dir, not a dangling one
                 _zigEnv[variable] = aliaser.DirAlias(dir);
@@ -134,26 +143,33 @@ public sealed class AotAnywhereWindowsLink : MSBuildTask
         return true;
     }
 
-    /// zig's cache directories surface in the printed line too (crt2.obj, the
-    /// MinGW import libraries live there). Mirrors zig's own resolution:
-    /// explicit env var, else XDG_CACHE_HOME/zig, else HOME/.cache/zig.
-    static List<(string Variable, string Dir)> ZigCacheDirsNeedingAlias()
+    /// zig's cache directories surface in the printed line too: the compiled
+    /// glue object lands in the local cache, crt2.obj and the MinGW import
+    /// libraries in the global one. Resolves both to what the caller then
+    /// pins via the env vars. Global: the explicit env var, else
+    /// XDG_CACHE_HOME/zig, else HOME/.cache/zig. Local: the explicit env
+    /// var, else the resolved global dir - which is what zig cc itself does
+    /// outside a build.zig tree (its ancestor build.zig discovery is
+    /// deliberately overridden - see AliasSpacedPaths).
+    public static List<(string Variable, string Dir)> ResolveZigCacheDirs(Func<string, string?> getEnv)
     {
-        var xdg = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+        var xdg = getEnv("XDG_CACHE_HOME");
         var defaultDir = Path.Combine(
             string.IsNullOrEmpty(xdg)
-                ? Path.Combine(Environment.GetEnvironmentVariable("HOME") ?? ".", ".cache")
+                ? Path.Combine(getEnv("HOME") ?? ".", ".cache")
                 : xdg,
             "zig");
 
-        var dirs = new List<(string, string)>();
-        foreach (var variable in new[] { "ZIG_GLOBAL_CACHE_DIR", "ZIG_LOCAL_CACHE_DIR" })
+        // netstandard2.0's IsNullOrEmpty has no nullability annotation; the
+        // patterns keep the flow analysis (and so the build) warning-free.
+        var globalDir = getEnv("ZIG_GLOBAL_CACHE_DIR") is { Length: > 0 } g ? g : defaultDir;
+        var localDir = getEnv("ZIG_LOCAL_CACHE_DIR") is { Length: > 0 } l ? l : globalDir;
+
+        return new List<(string Variable, string Dir)>
         {
-            var dir = Environment.GetEnvironmentVariable(variable);
-            if (string.IsNullOrEmpty(dir)) dir = defaultDir;
-            if (LinkPathAliaser.HasSpace(dir)) dirs.Add((variable, dir));
-        }
-        return dirs;
+            ("ZIG_GLOBAL_CACHE_DIR", globalDir),
+            ("ZIG_LOCAL_CACHE_DIR", localDir),
+        };
     }
 
     static void CreateSymlink(string target, string linkPath)

--- a/tests/AotAnywhere.MSBuild.Tests/ZigCacheDirsTests.cs
+++ b/tests/AotAnywhere.MSBuild.Tests/ZigCacheDirsTests.cs
@@ -1,0 +1,59 @@
+using AotAnywhere.Tasks;
+
+namespace AotAnywhere.MSBuild.Tests;
+
+// The cache-dir resolution the /OPT re-link pass pins onto zig via
+// ZIG_GLOBAL_CACHE_DIR/ZIG_LOCAL_CACHE_DIR. Both vars are always pinned:
+// unpinned, zig cc roots its local cache at `.zig-cache` under the nearest
+// ancestor directory holding a build.zig, so the glue object could surface in
+// the printed lld-link line at a spaced path the aliasing never predicted
+// (issue #67). Pure logic; the environment is injected.
+public class ZigCacheDirsTests
+{
+    static Func<string, string?> Env(params (string Name, string Value)[] vars) =>
+        name => vars.Where(v => v.Name == name).Select(v => v.Value).FirstOrDefault();
+
+    [Test]
+    public async Task ExplicitEnvVarsWinVerbatim()
+    {
+        var dirs = AotAnywhereWindowsLink.ResolveZigCacheDirs(Env(
+            ("ZIG_GLOBAL_CACHE_DIR", "/g cache"),
+            ("ZIG_LOCAL_CACHE_DIR", "/l cache"),
+            ("HOME", "/home/u")));
+
+        await Assert.That(dirs.Count).IsEqualTo(2);
+        await Assert.That(dirs[0]).IsEqualTo(("ZIG_GLOBAL_CACHE_DIR", "/g cache"));
+        await Assert.That(dirs[1]).IsEqualTo(("ZIG_LOCAL_CACHE_DIR", "/l cache"));
+    }
+
+    [Test]
+    public async Task UnsetVarsResolveToXdgCacheHomeZig()
+    {
+        var dirs = AotAnywhereWindowsLink.ResolveZigCacheDirs(Env(
+            ("XDG_CACHE_HOME", "/xdg"), ("HOME", "/home/u")));
+
+        await Assert.That(dirs[0].Dir).IsEqualTo("/xdg/zig");
+        await Assert.That(dirs[1].Dir).IsEqualTo("/xdg/zig");
+    }
+
+    [Test]
+    public async Task UnsetVarsAndNoXdgResolveToHomeDotCacheZig()
+    {
+        var dirs = AotAnywhereWindowsLink.ResolveZigCacheDirs(Env(("HOME", "/home/u")));
+
+        await Assert.That(dirs[0].Dir).IsEqualTo("/home/u/.cache/zig");
+        await Assert.That(dirs[1].Dir).IsEqualTo("/home/u/.cache/zig");
+    }
+
+    [Test]
+    public async Task LocalDefaultsToTheResolvedGlobalNotTheRawDefault()
+    {
+        // zig cc's own local fallback is the resolved global dir, so a global
+        // override must carry the local cache with it.
+        var dirs = AotAnywhereWindowsLink.ResolveZigCacheDirs(Env(
+            ("ZIG_GLOBAL_CACHE_DIR", "/ci/zig-cache"), ("HOME", "/home/u")));
+
+        await Assert.That(dirs[0].Dir).IsEqualTo("/ci/zig-cache");
+        await Assert.That(dirs[1].Dir).IsEqualTo("/ci/zig-cache");
+    }
+}


### PR DESCRIPTION
Closes #67. Investigation results for both items are in [the issue comment](https://github.com/slang25/AotAnywhere/issues/67); the short version:

- **Item 1 (local-cache default)** — the hypothesized default (`cwd/.zig-cache`) was wrong, but a real gap exists: `zig cc` roots its local cache at `.zig-cache` under the nearest ancestor directory holding a `build.zig` (else the global cache dir), and the compiled glue object always lands in the local cache and surfaces in the printed lld-link line. A `build.zig` ancestor under a spaced path therefore shatters the replay parse with a path `ZigCacheDirsNeedingAlias` never predicted — and it bypasses the guard's early return, because the *predicted* dirs are space-free.
- **Item 2 (PDB path desync)** — disproven. `zig cc` always passes `-PDBALTPATH:<output basename>` (verified for relative and absolute `-o`), and the CodeView RSDS record embedded in the produced PE contains exactly that basename, no directory. The replay preserves the token, so a spaced output directory never leaks the scratch alias into the image; debuggers resolve next-to-module by design. No change needed.

## The fix

Stop predicting zig's cache resolution and pin it: when the /OPT pass is active, always set `ZIG_GLOBAL_CACHE_DIR` and `ZIG_LOCAL_CACHE_DIR` explicitly (an explicit env var defeats zig's build-root discovery — verified), so the resolution the aliasing works from is exact by construction. The local fallback follows zig's own semantics: the *resolved* global dir, so a user's `ZIG_GLOBAL_CACHE_DIR` override carries the local cache with it (also verified against zig 0.16.0).

## Verification

- All empirical claims tested against zig 0.16.0 (the pinned toolset version): local default = resolved global; `build.zig` ancestor (not `build.zig.zon`, not a bare `.zig-cache` dir) switches it, printing an absolute spaced path; explicit env var wins over discovery; RSDS parsed out of produced PEs shows basename only.
- End-to-end repro of the fix: with a `build.zig` in a spaced ancestor, the pinned env vars route the glue object to the space-free global cache path in the lld-link line.
- `ResolveZigCacheDirs` made public with an injected environment; 4 new unit tests cover the fallback chain. Full suite: 62/62 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)