### PR TITLE
Fix Apple sysroot drift canary: run on Linux, restore before publish

### DIFF
--- a/.github/workflows/apple-sysroot-drift.yml
+++ b/.github/workflows/apple-sysroot-drift.yml
@@ -85,12 +85,18 @@ jobs:
             `PackVersions` (`eng/generate-apple-sysroot.cs`) to match, so a plain
             `dotnet run eng/generate-apple-sysroot.cs` reproduces this output.
 
-  # Canary: publish the sample app for osx-arm64 against the newest preview SDK.
-  # A missing Apple symbol surfaces here as a link failure even if the generator
-  # above did not flag it. Targets the newest preview TFM so the newest preview
-  # ILCompiler pack is exercised; bump both when a new preview major ships.
+  # Canary: cross-compile the sample app for osx-arm64 against the newest preview
+  # SDK. A missing Apple symbol surfaces here as a link failure even if the
+  # generator above did not flag it. Targets the newest preview TFM so the newest
+  # preview ILCompiler pack is exercised; bump both when a new preview major ships.
+  #
+  # Runs on Linux, NOT macOS, on purpose: a macOS host links against the real
+  # Apple SDK (-isysroot) and would satisfy a missing symbol from there, hiding
+  # the very gap this job exists to catch. A Linux host is a genuine cross-compile
+  # that links against the bundled src/apple-sysroot stubs - the real user
+  # scenario, and the only configuration where a stub gap turns the run red.
   canary:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     name: Canary publish (osx-arm64, newest preview SDK)
     steps:
       - name: Checkout repo
@@ -103,10 +109,19 @@ jobs:
           dotnet-quality: preview
 
       - name: Publish Hello for osx-arm64
+        # Restore explicitly before publishing: publish's implicit restore
+        # ignores the -p:TargetFramework override and restores the csproj's
+        # default TFM (net8.0), so the net11.0 build then fails NETSDK1005
+        # ("assets file doesn't have a target for net11.0"). An explicit restore
+        # honours the override; --no-restore keeps publish from redoing it.
         run: |
+          dotnet restore test/Hello.csproj \
+            -r osx-arm64 \
+            -p:TargetFramework=net11.0
           dotnet publish test/Hello.csproj \
             -r osx-arm64 \
             -c Release \
+            --no-restore \
             -p:TargetFramework=net11.0 \
             -p:InvariantGlobalization=true \
             --output artifacts/osx-arm64


### PR DESCRIPTION
The Apple sysroot drift workflow's canary job was failing red and, even when green, was linking against the real Apple SDK on its macOS runner — so a symbol missing from the bundled `src/apple-sysroot` stubs would be silently satisfied and never surface, defeating the job's purpose. This moves the canary to `ubuntu-latest`, where an osx-arm64 publish is a genuine cross-compile against the bundled stubs (the real user scenario). It also restores explicitly before publishing, because publish's implicit restore ignores `-p:TargetFramework` and restores the csproj default (net8.0), causing the net11.0 build to fail with `NETSDK1005`. Both fixes were verified locally against the .NET 11 preview 5 SDK; the stub-only net11 cross-link succeeds. The separate drift-regeneration job was already passing and is unchanged.