### PR TITLE
Canary: use external zig on PATH to fix cold-cache restore gap

### DIFF
--- a/.github/workflows/apple-sysroot-drift.yml
+++ b/.github/workflows/apple-sysroot-drift.yml
@@ -108,6 +108,19 @@ jobs:
           dotnet-version: '11.0.x'
           dotnet-quality: preview
 
+      # test/Hello.csproj imports src/*.targets directly instead of consuming
+      # the packed SDK, so NuGet cannot restore the host Zig toolset
+      # (Vezel.Zig.Toolsets.<host>) on a cold cache - the very gap the package's
+      # error message documents. Provide zig on PATH and set UseExternalZig=true
+      # (below) so the canary links host-side with it; the macOS target still
+      # links against the bundled src/apple-sysroot stubs, which is the point.
+      # Pinned to the same upstream release the package ships (guarded by
+      # eng/check-zig-version-sync.sh against src/ZigVersion.props).
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
       - name: Publish Hello for osx-arm64
         # Restore explicitly before publishing: publish's implicit restore
         # ignores the -p:TargetFramework override and restores the csproj's
@@ -117,12 +130,14 @@ jobs:
         run: |
           dotnet restore test/Hello.csproj \
             -r osx-arm64 \
-            -p:TargetFramework=net11.0
+            -p:TargetFramework=net11.0 \
+            -p:UseExternalZig=true
           dotnet publish test/Hello.csproj \
             -r osx-arm64 \
             -c Release \
             --no-restore \
             -p:TargetFramework=net11.0 \
+            -p:UseExternalZig=true \
             -p:InvariantGlobalization=true \
             --output artifacts/osx-arm64
           test -f artifacts/osx-arm64/Hello


### PR DESCRIPTION
Follow-up to #74. Moving the drift-detection canary to a Linux host surfaced the consumer zig-restore gap: because `test/Hello.csproj` imports `src/*.targets` directly rather than consuming the packed SDK, NuGet cannot restore the host `Vezel.Zig.Toolsets` package on a cold cache, so the canary failed with "the Zig toolset was not restored". This adds a `setup-zig` step (pinned to the same upstream release, guarded by `check-zig-version-sync.sh`) and passes `UseExternalZig=true` so the host links with the PATH zig, while the macOS target still links against the bundled `src/apple-sysroot` stubs — so the canary keeps guarding stub drift. Verified green via workflow_dispatch on the branch: both the regenerate-and-drift job and the canary publish pass.