### PR TITLE
Add support for the SDK's tool-package NAOT extensibility point

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,43 @@ dotnet publish -r linux-x64 /p:InvariantGlobalization=true
 Note that invariant globalization disables culture-specific formatting, sorting,
 and other globalization features.
 
+## Packing .NET tools for every platform (.NET 11+)
+
+Since .NET 10, a [.NET tool](https://learn.microsoft.com/dotnet/core/tools/global-tools)
+can ship native AOT binaries as one small "pointer" package plus one
+RID-specific package per platform — `dotnet tool install` downloads just the
+binary matching the user's machine. A single `dotnet pack` builds all of them,
+but the base SDK only packs the RIDs the host's native toolchain can build
+(e.g. a linux-x64 machine packs only linux-x64).
+
+With AotAnywhere referenced, that limit goes away: `dotnet pack` on one
+machine produces packages for **every** RID listed in
+`ToolPackageRuntimeIdentifiers` (or `RuntimeIdentifiers`), via the SDK's
+tool-packaging extensibility point
+([dotnet/sdk#55250](https://github.com/dotnet/sdk/pull/55250)).
+
+```xml
+<PropertyGroup>
+  <PackAsTool>true</PackAsTool>
+  <PublishAot>true</PublishAot>
+  <ToolPackageRuntimeIdentifiers>linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64;win-x64;win-arm64</ToolPackageRuntimeIdentifiers>
+</PropertyGroup>
+```
+
+```bash
+dotnet pack   # one host, one command, a package per RID
+```
+
+Things to know:
+
+- **Requires a .NET 11 SDK** with the extensibility point; on older SDKs the
+  hook is inert and the SDK's own host-capability rules apply.
+- Every requested RID is attempted, unfiltered — a RID this package can't
+  build fails its inner publish with a clear error rather than being silently
+  dropped from the set of produced packages.
+- Set `AotAnywhereMultiRidToolPackaging=false` to opt out and restore the
+  SDK's default host-capability selection.
+
 ## Compressing the output with UPX
 
 The published binary can optionally be compressed with

--- a/src/AotAnywhere.nuproj
+++ b/src/AotAnywhere.nuproj
@@ -50,6 +50,10 @@
       <Pack>true</Pack>
       <PackagePath>build</PackagePath>
     </None>
+    <None Include="ToolPack.targets">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
     <!-- Compiled into every macOS link by AotAnywhereDirectLinkMacNative
          (referenced via $(MSBuildThisFileDirectory)); must sit next to the
          targets in build/. -->

--- a/src/StuDev.AotAnywhere.targets
+++ b/src/StuDev.AotAnywhere.targets
@@ -11,4 +11,10 @@
        property. -->
   <Import Project="UpxCompress.targets" />
 
+  <!-- Multi-RID .NET tool packaging. Imported without the RID condition
+       because it must be active in the outer (RID-less) pack evaluation,
+       where the SDK asks which RID-specific tool packages this host can
+       build. -->
+  <Import Project="ToolPack.targets" />
+
 </Project>

--- a/src/ToolPack.targets
+++ b/src/ToolPack.targets
@@ -1,0 +1,41 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Multi-RID .NET tool packaging (dotnet/sdk#55250, .NET 11+).
+
+       When a tool project requests RID-specific packages (via
+       ToolPackageRuntimeIdentifiers or RuntimeIdentifiers), a single
+       `dotnet pack` orchestrates one inner pack per RID. For PublishAot tools
+       the base SDK clamps that to the RIDs the host's native toolchain can
+       build; ComputeToolPackageRuntimeIdentifiersToPack is its extensibility
+       point for packages that widen those capabilities. This package makes
+       every practical NativeAOT RID buildable from any supported host, so the
+       answer to "which requested RIDs can this host pack?" is: all of them.
+
+       On SDKs without the extensibility point the BeforeTargets reference is
+       ignored and this file is inert. Set
+       AotAnywhereMultiRidToolPackaging=false to fall back to the SDK's own
+       host-capability defaults. -->
+
+  <Target Name="_AotAnywhereSelectToolPackageRids"
+          BeforeTargets="ComputeToolPackageRuntimeIdentifiersToPack"
+          Condition="'$(RuntimeIdentifier)' == ''
+            and '$(CreateRidSpecificToolPackages)' == 'true'
+            and '$(AotAnywhereMultiRidToolPackaging)' != 'false'
+            and '@(ToolPackageRuntimeIdentifiersToPack)' == ''">
+
+    <PropertyGroup>
+      <!-- Same fallback the SDK's own default computation applies. -->
+      <_AotAnywhereToolPackageRids>$(ToolPackageRuntimeIdentifiers)</_AotAnywhereToolPackageRids>
+      <_AotAnywhereToolPackageRids Condition="'$(_AotAnywhereToolPackageRids)' == ''">$(RuntimeIdentifiers)</_AotAnywhereToolPackageRids>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Every requested RID, unfiltered: a RID neither this package nor the
+           SDK can build fails its inner publish with a clear error, which
+           beats silently dropping it from the set of produced packages. -->
+      <ToolPackageRuntimeIdentifiersToPack Include="$(_AotAnywhereToolPackageRids)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/tests/AotAnywhere.MSBuild.Tests/Harness.cs
+++ b/tests/AotAnywhere.MSBuild.Tests/Harness.cs
@@ -15,6 +15,11 @@ internal static class Harness
         Path.Combine(RepoRoot, "src") + Path.DirectorySeparatorChar;
     static readonly string HarnessProj =
         Path.Combine(RepoRoot, "tests", "AotAnywhere.MSBuild.Tests", "harness", "Harness.proj");
+    public const string ToolPackHarness = "ToolPackHarness.proj";
+
+    static string ProjPath(string? proj) =>
+        proj is null ? HarnessProj
+                     : Path.Combine(Path.GetDirectoryName(HarnessProj)!, proj);
 
     static string FindRepoRoot()
     {
@@ -46,12 +51,13 @@ internal static class Harness
     static readonly object BuildLock = new();
 
     // Executes a single target and returns its results (properties/items it set).
-    public static RunResult Run(string target, IDictionary<string, string> globals)
+    // `proj` selects an alternate harness project (e.g. ToolPackHarness).
+    public static RunResult Run(string target, IDictionary<string, string> globals, string? proj = null)
     {
         lock (BuildLock)
         {
             var collection = new ProjectCollection(Globals(globals));
-            var instance = collection.LoadProject(HarnessProj).CreateProjectInstance();
+            var instance = collection.LoadProject(ProjPath(proj)).CreateProjectInstance();
             var logger = new ErrorLogger();
             var success = instance.Build(new[] { target }, new ILogger[] { logger });
             return new RunResult(success, instance, logger.Errors);

--- a/tests/AotAnywhere.MSBuild.Tests/ToolPackRidSelectionTests.cs
+++ b/tests/AotAnywhere.MSBuild.Tests/ToolPackRidSelectionTests.cs
@@ -1,0 +1,100 @@
+namespace AotAnywhere.MSBuild.Tests;
+
+// _AotAnywhereSelectToolPackageRids (ToolPack.targets) answers the SDK's
+// ComputeToolPackageRuntimeIdentifiersToPack extensibility point
+// (dotnet/sdk#55250): which of the requested RIDs can this host pack? With
+// this package referenced, all of them. The target is executed directly by
+// name so the tests run on SDKs that predate the extensibility point.
+public class ToolPackRidSelectionTests
+{
+    const string Target = "_AotAnywhereSelectToolPackageRids";
+    const string Item = "ToolPackageRuntimeIdentifiersToPack";
+
+    const string AllRids =
+        "linux-x64;linux-arm64;linux-arm;linux-musl-x64;linux-musl-arm64;linux-musl-arm;osx-x64;osx-arm64;win-x64;win-arm64";
+
+    static Dictionary<string, string> Globals(
+        string toolPackageRids = "",
+        string runtimeIdentifiers = "",
+        string createRidSpecificToolPackages = "true",
+        string runtimeIdentifier = "") =>
+        new()
+        {
+            ["ToolPackageRuntimeIdentifiers"] = toolPackageRids,
+            ["RuntimeIdentifiers"] = runtimeIdentifiers,
+            ["CreateRidSpecificToolPackages"] = createRidSpecificToolPackages,
+            ["RuntimeIdentifier"] = runtimeIdentifier,
+        };
+
+    [Test]
+    public async Task EmitsEveryRequestedRid()
+    {
+        var run = Harness.Run(Target, Globals(toolPackageRids: AllRids), Harness.ToolPackHarness);
+        await Assert.That(run.Success).IsTrue();
+        await Assert.That(string.Join(";", run.Items(Item))).IsEqualTo(AllRids);
+    }
+
+    [Test]
+    public async Task FallsBackToRuntimeIdentifiers()
+    {
+        var run = Harness.Run(
+            Target,
+            Globals(runtimeIdentifiers: "linux-x64;osx-arm64"),
+            Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEquivalentTo(new[] { "linux-x64", "osx-arm64" });
+    }
+
+    [Test]
+    public async Task ToolPackageRidsWinOverRuntimeIdentifiers()
+    {
+        var run = Harness.Run(
+            Target,
+            Globals(toolPackageRids: "win-arm64", runtimeIdentifiers: "linux-x64;osx-arm64"),
+            Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEquivalentTo(new[] { "win-arm64" });
+    }
+
+    // Not a RID-specific tool pack (property empty or false): stay out of the way.
+    [Test]
+    [Arguments("")]
+    [Arguments("false")]
+    public async Task InactiveWithoutRidSpecificToolPackaging(string createRidSpecificToolPackages)
+    {
+        var run = Harness.Run(
+            Target,
+            Globals(toolPackageRids: AllRids, createRidSpecificToolPackages: createRidSpecificToolPackages),
+            Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEmpty();
+    }
+
+    // Inner RID-specific pack builds compute nothing; only the outer build selects.
+    [Test]
+    public async Task InactiveInInnerRidSpecificBuild()
+    {
+        var run = Harness.Run(
+            Target,
+            Globals(toolPackageRids: AllRids, runtimeIdentifier: "linux-x64"),
+            Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEmpty();
+    }
+
+    [Test]
+    public async Task OptOutRestoresSdkDefaults()
+    {
+        var globals = Globals(toolPackageRids: AllRids);
+        globals["AotAnywhereMultiRidToolPackaging"] = "false";
+        var run = Harness.Run(Target, globals, Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEmpty();
+    }
+
+    // A user's evaluation-time ToolPackageRuntimeIdentifiersToPack items are
+    // authoritative; the target must not append to them.
+    [Test]
+    public async Task PredefinedItemsAreRespected()
+    {
+        var globals = Globals(toolPackageRids: AllRids);
+        globals["TestPredefinedToolPackRids"] = "osx-arm64;win-arm64";
+        var run = Harness.Run(Target, globals, Harness.ToolPackHarness);
+        await Assert.That(run.Items(Item)).IsEquivalentTo(new[] { "osx-arm64", "win-arm64" });
+    }
+}

--- a/tests/AotAnywhere.MSBuild.Tests/harness/ToolPackHarness.proj
+++ b/tests/AotAnywhere.MSBuild.Tests/harness/ToolPackHarness.proj
@@ -1,0 +1,20 @@
+<Project>
+
+  <!-- Tool-packaging harness. Imports the package's real entry-point targets
+       the way NuGet's build/ auto-import does, so tests exercise the outer
+       (RID-less) pack evaluation where _AotAnywhereSelectToolPackageRids
+       runs. Inputs are injected as MSBuild global properties by the test;
+       @(ToolPackageRuntimeIdentifiersToPack) is seeded from the
+       semicolon-delimited $(TestPredefinedToolPackRids) property because
+       items cannot be passed as global properties.
+
+       $(AotAnywhereSrcDir) is supplied by the test as an absolute path to the
+       repo's src/ directory. -->
+
+  <ItemGroup>
+    <ToolPackageRuntimeIdentifiersToPack Include="$(TestPredefinedToolPackRids)" />
+  </ItemGroup>
+
+  <Import Project="$(AotAnywhereSrcDir)StuDev.AotAnywhere.targets" />
+
+</Project>


### PR DESCRIPTION
Hooks the `ComputeToolPackageRuntimeIdentifiersToPack` extensibility point merged in dotnet/sdk#55250 (.NET 11+), as requested by @baronfel, so a single `dotnet pack` on one host produces RID-specific AOT tool packages for every RID in `ToolPackageRuntimeIdentifiers` instead of only the RIDs the host's native toolchain can build. The new packed `build/ToolPack.targets` emits one `ToolPackageRuntimeIdentifiersToPack` item per requested RID (mirroring the SDK's `ToolPackageRuntimeIdentifiers` → `RuntimeIdentifiers` fallback), stays out of the way in inner RID-specific builds and when the user predefines their own items, and supports opting out via `AotAnywhereMultiRidToolPackaging=false`. On SDKs without the extensibility point the `BeforeTargets` reference is ignored, so the file is inert and safe to ship now. Includes 7 MSBuild-harness tests via a new outer-evaluation harness project, plus a README section documenting the flow and the .NET 11 SDK requirement.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)