### PR TITLE
Remove per-host NuGet caching from cross-platform validation

### DIFF
--- a/.github/scripts/build-targets.sh
+++ b/.github/scripts/build-targets.sh
@@ -25,8 +25,9 @@ export PATH="$PWD/.rcodesign:$PATH"
 # - producing "Directory not empty", missing-temp-file, and http-cache
 # `.dat-new` errors. Serial pre-warming doesn't help (macOS still re-extracts),
 # so isolate the folders per group instead: nothing shared, no collision.
-# $RUNNER_TEMP is a native path on every host, so this is safe on Windows too,
-# and the cache step archives the whole $RUNNER_TEMP/nuget tree.
+# $RUNNER_TEMP is a native path on every host, so this is safe on Windows too.
+# Each group re-downloads its packages from nuget.org every run; that's
+# deliberate (see the no-caching note in cross-platform-validation.yml).
 #
 # (coreclr's other shared resource, its /tmp/.dotnet/shm/session<id> dir, is a
 # FIXED path that TMPDIR does NOT relocate, so it can't be isolated the same

--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -180,18 +180,12 @@ jobs:
             9.0.x
             10.0.x
 
-      # The publishes below restore the Vezel zig toolset for this host plus
-      # ILCompiler/runtime packs for all eight target RIDs - several hundred
-      # MB from nuget.org on every run without this cache. build-targets.sh
-      # gives each concurrent group its own NuGet folders under
-      # $RUNNER_TEMP/nuget (see below), so cache that whole tree.
-      - name: Cache NuGet packages
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/nuget
-          key: nuget-publish-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/AotAnywhere.nuproj', 'src/Crosscompile.targets', 'test/Hello.csproj', 'test/HelloLib/HelloLib.csproj') }}
-          restore-keys: |
-            nuget-publish-${{ runner.os }}-${{ runner.arch }}-
+      # No NuGet caching here: the per-group NuGet folders under
+      # $RUNNER_TEMP/nuget (see build-targets.sh) add up to ~5GB per host,
+      # so three host caches blow the 10GB repo limit and evict each other -
+      # chronic misses, while the post-job save alone cost 3-5 minutes.
+      # Downloading from nuget.org's CDN each run is cheaper than either
+      # side of that cache.
 
       - name: Download test signing certificate
         uses: actions/download-artifact@v8


### PR DESCRIPTION
The build jobs' NuGet cache was net-negative: each host's per-group NuGet tree is ~5GB, so three host caches blow GitHub's 10GB per-repo cache limit and evict each other, producing chronic misses. Meanwhile the post-job cache save alone cost 3-5 minutes per build job (4m43s on windows in [this run](https://github.com/StuDevLabs/AotAnywhere/actions/runs/29581202834/job/87887481613)), while restores completed in ~1s — i.e. misses. Downloading from nuget.org's CDN each run is cheaper than either side of that cache, so this removes the cache step and documents the reasoning in the workflow and in build-targets.sh. The stale 5GB cache entry has also been deleted from the repo's Actions cache storage, freeing the pool for main.yml's small nuget-ci cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)